### PR TITLE
Python 3 compatibility

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -99,7 +99,7 @@ class PeriodicTaskForm(forms.ModelForm):
 class PeriodicTaskAdmin(admin.ModelAdmin):
     form = PeriodicTaskForm
     model = PeriodicTask
-    list_display = ('__unicode__', 'enabled')
+    list_display = ('__str__', 'enabled')
     fieldsets = (
         (None, {
             'fields': ('name', 'regtask', 'task', 'enabled'),


### PR DESCRIPTION
Apply Django build-in decorator python_2_unicode_compatible() for compatibility with Python 2/3 both.

It solves the issue #1 .