### PR TITLE
Force to rebuild cached periodic task configuration.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -282,4 +282,6 @@ class DatabaseScheduler(Scheduler):
                 debug('Current schedule:\n%s', '\n'.join(
                     repr(entry) for entry in values(self._schedule)),
                 )
+            # _heap will be rebuilt on the next run
+            super(Scheduler, self).__setattr__('_heap', None)
         return self._schedule


### PR DESCRIPTION
Force to rebuild cached periodic task configuration for Database Scheduler.

Fixes https://github.com/celery/django-celery-beat/issues/7