### PR TITLE
delete CharField null=True

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -244,14 +244,14 @@ class PeriodicTask(models.Model):
         help_text=_('JSON encoded keyword arguments'),
     )
     queue = models.CharField(
-        _('queue'), max_length=200, blank=True, null=True, default=None,
+        _('queue'), max_length=200, blank=True, default=None,
         help_text=_('Queue defined in CELERY_TASK_QUEUES'),
     )
     exchange = models.CharField(
-        _('exchange'), max_length=200, blank=True, null=True, default=None,
+        _('exchange'), max_length=200, blank=True, default=None,
     )
     routing_key = models.CharField(
-        _('routing key'), max_length=200, blank=True, null=True, default=None,
+        _('routing key'), max_length=200, blank=True, default=None,
     )
     expires = models.DateTimeField(
         _('expires'), blank=True, null=True,


### PR DESCRIPTION
[Null](https://docs.djangoproject.com/en/1.10/ref/models/fields/#null)

>Avoid using null on string-based fields such as CharField and TextField because empty string values will always be stored as empty strings, not as NULL. If a string-based field has null=True, that means it has two possible values for “no data”: NULL, and the empty string. In most cases, it’s redundant to have two possible values for “no data;” the Django convention is to use the empty string, not NULL.