### PR TITLE
Small fix: css class conflict with django-adminlte2 package

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -128,11 +128,11 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
         }),
         ('Arguments', {
             'fields': ('args', 'kwargs'),
-            'classes': ('extrapretty', 'wide', 'collapse'),
+            'classes': ('extrapretty', 'wide', 'collapse', 'in'),
         }),
         ('Execution Options', {
             'fields': ('expires', 'queue', 'exchange', 'routing_key'),
-            'classes': ('extrapretty', 'wide', 'collapse'),
+            'classes': ('extrapretty', 'wide', 'collapse', 'in'),
         }),
     )
 

--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -149,7 +149,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
 
     def enable_tasks(self, request, queryset):
         rows_updated = queryset.update(enabled=True)
-        PeriodicTasks.changed()
+        PeriodicTasks.update_changed()
         self.message_user(
             request,
             _('{0} task{1} {2} successfully enabled').format(
@@ -162,7 +162,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
 
     def disable_tasks(self, request, queryset):
         rows_updated = queryset.update(enabled=False)
-        PeriodicTasks.changed()
+        PeriodicTasks.update_changed()
         self.message_user(
             request,
             _('{0} task{1} {2} successfully disabled').format(


### PR DESCRIPTION
Hi,

I am using this package with [django-adminlte2](https://github.com/adamcharnock/django-adminlte2) and had a issue in the PeriodicTask Admin page, the Agruments and Execution Options boxes disappeared when I clicked the "Show" button. 

This PR will add `in` class to the box to fix the issue above.

Thanks