### PR TITLE
Fix PeriodicTask.enable sync issues

### DIFF
--- a/django_celery_beat/migrations/0004_auto_20170221_0000.py
+++ b/django_celery_beat/migrations/0004_auto_20170221_0000.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_celery_beat', '0003_auto_20161209_0049'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='solarschedule',
+            name='longitude',
+            field=models.DecimalField(
+                verbose_name='longitude',
+                max_digits=9,
+                decimal_places=6),
+        ),
+    ]

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -249,7 +249,9 @@ class DatabaseScheduler(Scheduler):
         s = {}
         for name, entry_fields in items(mapping):
             try:
-                entry = self.Entry.from_entry(name, app=self.app, **entry_fields)
+                entry = self.Entry.from_entry(name,
+                                              app=self.app,
+                                              **entry_fields)
                 if entry.model.enabled:
                     s[name] = entry
 
@@ -283,6 +285,8 @@ class DatabaseScheduler(Scheduler):
         if update:
             self.sync()
             self._schedule = self.all_as_schedule()
+            # the schedule changed, invalidate the heap in Scheduler.tick
+            self._heap = None
             if logger.isEnabledFor(logging.DEBUG):
                 debug('Current schedule:\n%s', '\n'.join(
                     repr(entry) for entry in values(self._schedule)),

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -247,11 +247,14 @@ class DatabaseScheduler(Scheduler):
 
     def update_from_dict(self, mapping):
         s = {}
-        for name, entry in items(mapping):
+        for name, entry_fields in items(mapping):
             try:
-                s[name] = self.Entry.from_entry(name, app=self.app, **entry)
+                entry = self.Entry.from_entry(name, app=self.app, **entry_fields)
+                if entry.model.enabled:
+                    s[name] = entry
+
             except Exception as exc:
-                logger.error(ADD_ENTRY_ERROR, name, exc, entry)
+                logger.error(ADD_ENTRY_ERROR, name, exc, entry_fields)
         self.schedule.update(s)
 
     def install_default_entries(self, data):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -222,7 +222,7 @@ class DatabaseScheduler(Scheduler):
         return False
 
     def reserve(self, entry):
-        new_entry = Scheduler.reserve(self, entry)
+        new_entry = next(entry)
         # Need to store entry by name, because the entry may change
         # in the mean time.
         self._dirty.add(new_entry.name)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -118,6 +118,7 @@ class test_ModelEntry(SchedulerCase):
         assert e3.last_run_at > e2.last_run_at
         assert e3.total_run_count == 1
 
+
 @pytest.mark.django_db()
 class test_DatabaseSchedulerFromAppConf(SchedulerCase):
     Scheduler = TrackingScheduler
@@ -157,6 +158,7 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         assert len(sched) == 1
         assert 'celery.backend_cleanup' in sched
         assert self.entry_name not in sched
+
 
 @pytest.mark.django_db()
 class test_DatabaseScheduler(SchedulerCase):
@@ -275,7 +277,7 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # Increment the entry (but make sure it doesn't sync)
         self.s._last_sync = monotonic()
-        e2 = self.s.schedule[e1.name] = self.s.reserve(e1)
+        self.s.schedule[e1.name] = self.s.reserve(e1)
         assert self.s.flushed == 1
 
         # Fetch the raw object from db, change the args

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -64,6 +64,17 @@ class SchedulerCase:
         crontab.save()
         return self.create_model(crontab=crontab, **kwargs)
 
+    def create_conf_entry(self):
+        name = 'thefoo{0}'.format(next(_ids))
+        return name, dict(
+            task='djcelery.unittest.add{0}'.format(next(_ids)),
+            schedule=timedelta(0, 600),
+            args=(),
+            relative=False,
+            kwargs={},
+            options={'queue': 'extra_queue'}
+        )
+
     def create_model(self, Model=PeriodicTask, **kwargs):
         entry = dict(
             name='thefoo{0}'.format(next(_ids)),
@@ -107,6 +118,45 @@ class test_ModelEntry(SchedulerCase):
         assert e3.last_run_at > e2.last_run_at
         assert e3.total_run_count == 1
 
+@pytest.mark.django_db()
+class test_DatabaseSchedulerFromAppConf(SchedulerCase):
+    Scheduler = TrackingScheduler
+
+    @pytest.mark.django_db()
+    @pytest.fixture(autouse=True)
+    def setup_scheduler(self, app):
+        self.app = app
+
+        self.entry_name, entry = self.create_conf_entry()
+        self.app.conf.beat_schedule = {self.entry_name: entry}
+        self.m1 = PeriodicTask(name=self.entry_name)
+
+    def test_constructor(self):
+        s = self.Scheduler(app=self.app)
+
+        assert isinstance(s._dirty, set)
+        assert s._last_sync is None
+        assert s.sync_every
+
+    def test_periodic_task_model_enabled_schedule(self):
+        s = self.Scheduler(app=self.app)
+        sched = s.schedule
+        assert len(sched) == 2
+        assert 'celery.backend_cleanup' in sched
+        assert self.entry_name in sched
+        for n, e in sched.items():
+            assert isinstance(e, s.Entry)
+
+    def test_periodic_task_model_disabled_schedule(self):
+        self.m1.enabled = False
+        self.m1.save()
+
+        s = self.Scheduler(app=self.app)
+        sched = s.schedule
+        assert sched
+        assert len(sched) == 1
+        assert 'celery.backend_cleanup' in sched
+        assert self.entry_name not in sched
 
 @pytest.mark.django_db()
 class test_DatabaseScheduler(SchedulerCase):
@@ -130,6 +180,12 @@ class test_DatabaseScheduler(SchedulerCase):
             crontab(minute='2,4,5'))
         self.m3.save()
         self.m3.refresh_from_db()
+
+        # disabled, should not be in schedule
+        m4 = self.create_model_interval(
+            schedule(timedelta(seconds=1)))
+        m4.enabled = False
+        m4.save()
 
         self.s = self.Scheduler(app=self.app)
 


### PR DESCRIPTION
Hi!

We recently upgraded to Celery 4 and django_celery_beat. We use PeriodTasks and occasionally disable them by setting `PeriodTask.enabled` to False. After upgrading, we noticed that this functionality has stopped working with django_celery_beat.

This pull request adds test cases and fixes for the issues that I observed when troubleshooting the beat command:

1. Calling `Scheduler.reserve(self, entry)` causes the parent class to call `self.schedule[new_entry]` which will add the disabled task back into self._schedule if has recently been run.

2. When the DatabaseScheduler constructor calls `self.update_from_dict(self.app.conf.beat_schedule)`, and entries in beat_schedule will be added to self._schedule, even if the entry has enabled=False in the database.

3. When update is True in `DatabaseScheduler.schedule` and the schedule is fetched by `all_as_schedule`, `self._heap` needs to be set to None so that tick will rebuild the heap which reflects the changed schedule

Happy to discuss these changes! Thanks!