### PR TITLE
Package name should be with dashes not underscores

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ except (AttributeError, ImportError):
     def _pyimp():
         return 'Python'
 
-NAME = 'django_celery_beat'
+NAME = 'django-celery-beat'
+PACKAGE = 'django_celery_beat'
 
 E_UNSUPPORTED_PYTHON = '%s 1.0 requires %%s %%s or later!' % (NAME,)
 
@@ -74,7 +75,7 @@ def add_doc(m):
 pats = {re_meta: add_default,
         re_doc: add_doc}
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, NAME, '__init__.py')) as meta_fh:
+with open(os.path.join(here, PACKAGE, '__init__.py')) as meta_fh:
     meta = {}
     for line in meta_fh:
         if line.strip() == '# -eof meta-':


### PR DESCRIPTION
There is some problem when `name` is with underscores and not dashes. In some situations `pip` or `wheel` replaces underscores with dashes. When package is installed and in the output of `pip freeze` it is with dashes.

The problem is when asking the XMLRPC API (https://pypi.python.org/pypi) for getting available versions of the package. Then if asked with dashes (as printed by `pip freeze`) then the API does not find the package because it expect to be with underscores.

The easiest way to see the problem is with `manage.py pipchecker` command from `djangno-extensions`.