### PR TITLE
Prevent MySQL has gone away errors

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -13,7 +13,7 @@ from celery.utils.encoding import safe_str, safe_repr
 from celery.utils.log import get_logger
 from kombu.utils.json import dumps, loads
 
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.utils import DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -232,6 +232,7 @@ class DatabaseScheduler(Scheduler):
         info('Writing entries...')
         _tried = set()
         try:
+            close_old_connections()
             with transaction.atomic():
                 while self._dirty:
                     try:


### PR DESCRIPTION
Prevents Error "MySQL has gone away" when Django tries to go through old, timed-out or closed connections.
After calling close_old_connections() Django opens a new connection if the old one was closed.