### PR TITLE
Fix interval schedules by providing nowfun.

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -60,9 +60,9 @@ class SolarSchedule(models.Model):
 
     @property
     def schedule(self):
-        return schedules.solar(self.event, 
-                               self.latitude, 
-                               self.longitude, 
+        return schedules.solar(self.event,
+                               self.latitude,
+                               self.longitude,
                                nowfun=lambda: make_aware(now()))
 
     @classmethod
@@ -112,7 +112,10 @@ class IntervalSchedule(models.Model):
 
     @property
     def schedule(self):
-        return schedules.schedule(timedelta(**{self.period: self.every}))
+        return schedules.schedule(
+            timedelta(**{self.period: self.every}),
+            nowfun=lambda: make_aware(now())
+        )
 
     @classmethod
     def from_schedule(cls, schedule, period=SECONDS):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -13,6 +13,8 @@ from celery.utils.encoding import safe_str, safe_repr
 from celery.utils.log import get_logger
 from kombu.utils.json import dumps, loads
 
+from datetime import timezone
+
 from django.db import transaction
 from django.db.utils import DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
@@ -85,10 +87,7 @@ class ModelEntry(ScheduleEntry):
 
         if not model.last_run_at:
             model.last_run_at = self._default_now()
-        orig = self.last_run_at = model.last_run_at
-        if not is_naive(self.last_run_at):
-            self.last_run_at = self.last_run_at.replace(tzinfo=None)
-        assert orig.hour == self.last_run_at.hour  # timezone sanity
+        self.last_run_at = make_aware(model.last_run_at)
 
     def _disable(self, model):
         model.no_changes = True

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -13,8 +13,6 @@ from celery.utils.encoding import safe_str, safe_repr
 from celery.utils.log import get_logger
 from kombu.utils.json import dumps, loads
 
-from datetime import timezone
-
 from django.db import transaction
 from django.db.utils import DatabaseError
 from django.core.exceptions import ObjectDoesNotExist

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -98,7 +98,11 @@ class ModelEntry(ScheduleEntry):
         return self.schedule.is_due(self.last_run_at)
 
     def _default_now(self):
-        return self.app.now()
+        now = self.app.now()
+        # The PyTZ datetime must be localised for the Django-Celery-Beat
+        # scheduler to work. Keep in mind that timezone arithmatic
+        # with a localized timezone may be inaccurate.
+        return now.tzinfo.localize(now.replace(tzinfo=None))
 
     def __next__(self):
         self.model.last_run_at = self.app.now()
@@ -113,7 +117,6 @@ class ModelEntry(ScheduleEntry):
         obj = type(self.model)._default_manager.get(pk=self.model.pk)
         for field in self.save_fields:
             setattr(obj, field, getattr(self.model, field))
-        obj.last_run_at = make_aware(obj.last_run_at)
         obj.save()
 
     @classmethod

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -444,7 +444,7 @@ class test_models(SchedulerCase):
 
         assert s.schedule is not None
         isdue, nextcheck = s.schedule.is_due(dt_lastrun)
-        assert isdue is False  # False means task is not due, but keep checking.
+        assert isdue is False  # False means task isn't due, but keep checking.
         assert (nextcheck > 0) and (isdue is False) or \
             (nextcheck == s.max_interval) and (isdue is True)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -439,15 +439,24 @@ class test_models(SchedulerCase):
 
     def test_SolarSchedule_schedule(self):
         s = SolarSchedule(event='solar_noon', latitude=48.06, longitude=12.86)
-        dt = datetime(day=25, month=7, year=2017, hour=12, minute=0)
+        dt = datetime(day=26, month=7, year=2050, hour=1, minute=0)
         dt_lastrun = make_aware(dt)
 
         assert s.schedule is not None
-
         isdue, nextcheck = s.schedule.is_due(dt_lastrun)
-        assert isdue is False  # False means scheduler needs to keep checking.
+        assert isdue is False  # False means task is not due, but keep checking.
         assert (nextcheck > 0) and (isdue is False) or \
             (nextcheck == s.max_interval) and (isdue is True)
+
+        s2 = SolarSchedule(event='solar_noon', latitude=48.06, longitude=12.86)
+        dt2 = datetime(day=26, month=7, year=2000, hour=1, minute=0)
+        dt2_lastrun = make_aware(dt2)
+
+        assert s2.schedule is not None
+        isdue2, nextcheck2 = s2.schedule.is_due(dt2_lastrun)
+        assert isdue2 is True  # True means task is due and should run.
+        assert (nextcheck2 > 0) and (isdue2 is True) or \
+            (nextcheck2 == s2.max_interval) and (isdue2 is False)
 
 
 @pytest.mark.django_db()

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -118,11 +118,11 @@ class test_ModelEntry(SchedulerCase):
         assert e.options['routing_key'] == 'cpu'
 
         right_now = self.app.now()
-        
         m2 = self.create_model_interval(
             schedule(timedelta(seconds=10)),
             last_run_at=right_now,
         )
+
         assert m2.last_run_at
         e2 = self.Entry(m2, app=self.app)
         assert e2.last_run_at is right_now

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -118,8 +118,7 @@ class test_ModelEntry(SchedulerCase):
         assert e.options['routing_key'] == 'cpu'
 
         right_now = self.app.now()
-        # Entry.last_run_at returns naive tz, so make this naive for comparison
-        right_now = right_now.replace(tzinfo=None)
+        
         m2 = self.create_model_interval(
             schedule(timedelta(seconds=10)),
             last_run_at=right_now,


### PR DESCRIPTION
Fix for https://github.com/celery/django-celery-beat/issues/67

I have thoroughly tested that solar, interval and crontab tasks all work as expected when run simultaneously with my changes.

Also fixing solar test.

Django_celery_beat is approaching the point of actually being usable ;)