### PR TITLE
add on_delete=CASCADE on models PeriodicTask

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -233,10 +233,12 @@ class PeriodicTask(models.Model):
     interval = models.ForeignKey(
         IntervalSchedule, on_delete=models.CASCADE,
         null=True, blank=True, verbose_name=_('interval'),
+	on_delete=models.CASCADE
     )
     crontab = models.ForeignKey(
         CrontabSchedule, on_delete=models.CASCADE, null=True, blank=True,
         verbose_name=_('crontab'), help_text=_('Use one of interval/crontab'),
+	 on_delete=models.CASCADE
     )
     solar = models.ForeignKey(
         SolarSchedule, on_delete=models.CASCADE, null=True, blank=True,


### PR DESCRIPTION
to Django 2.0

TypeError: __init__() missing 1 required positional argument: 'on_delete'