### PR TITLE
Adds field PeriodicTask.origin_key to sync tasks with settings.beat_schedule

### DIFF
--- a/django_celery_beat/migrations/0006_periodictask_origin_key.py
+++ b/django_celery_beat/migrations/0006_periodictask_origin_key.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_celery_beat', '0005_add_solarschedule_events_choices'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='periodictask',
+            name='origin_key',
+            field=models.CharField(
+                blank=True,
+                default=None,
+                max_length=200,
+                null=True,
+                verbose_name='origin key'
+            ),
+        ),
+    ]

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -260,6 +260,9 @@ class PeriodicTask(models.Model):
     routing_key = models.CharField(
         _('routing key'), max_length=200, blank=True, null=True, default=None,
     )
+    origin_key = models.CharField(
+        _('origin key'), max_length=200, blank=True, null=True, default=None,
+    )
     expires = models.DateTimeField(
         _('expires'), blank=True, null=True,
     )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -142,12 +142,19 @@ class ModelEntry(ScheduleEntry):
                        args=None, kwargs=None, relative=None, options=None,
                        **entry):
         model_schedule, model_field = cls.to_model_schedule(schedule)
+        schedules = {
+            'interval': None,
+            'crontab': None,
+            'solar': None
+        }
+        schedules[model_field] = model_schedule
+
+        entry.update(**schedules)
         entry.update(
-            {model_field: model_schedule},
             args=dumps(args or []),
             kwargs=dumps(kwargs or {}),
-            **cls._unpack_options(**options or {})
         )
+        entry.update(**cls._unpack_options(**options or {}))
         return entry
 
     @classmethod


### PR DESCRIPTION
This adds a field `PeriodicTask.origin_key` which indicates if a task database row was populated dynamically or from source code (e.g. `settings.CELERYBEAT_SCHEDULE` or `settings.beat_schedule` in `4.1+`).

If an entry is removed from `settings.CELERYBEAT_SCHEDULE` it will also delete any previously populated database row for `PeriodicTask`.

E.g.

```
# before
CELERYBEAT_SCHEDULE = {
    'test-sms': {
        'task': 'app.tasks.test_sms',
        'schedule': datetime.timedelta(seconds=60),
        'args': None
    },
}

# after
CELERYBEAT_SCHEDULE = {
    # 'test-sms': {
    #     'task': 'app.tasks.test_sms',
    #     'schedule': datetime.timedelta(seconds=60),
    #     'args': None
    # },
}
```

After commenting out the above, celery beat would purge the task from database and also emit this logger statement:

```
[2018-02-09 13:51:48,345: WARNING/Beat] Purged periodic tasks [origin_key=beat_schedule]: test-sms
```

See: f0a5eb4