### PR TITLE
Fixes a problem with beat not reconnecting to MySQL (server restart, …

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -219,6 +219,7 @@ class DatabaseScheduler(Scheduler):
         return s
 
     def schedule_changed(self):
+        close_old_connections()
         try:
             # If MySQL is running with transaction isolation level
             # REPEATABLE-READ (default), then we won't see changes done by


### PR DESCRIPTION
When beat checks if schedule has changes it may hit a MySQL connection that has been closed (server restart, network problem, connection timeout, etc.). This results in an endless loop of "MySQL has gone away" errors and beat not being able to check the schedule until process restart. 

The problem has been discussed for quite some time. I've made every schedule change check begin with closing old connections. This way beat survives MySQL restarts and reconnect successfully