### PR TITLE
Fix: invalidate heap to an empty list and not None

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -192,7 +192,7 @@ class DatabaseScheduler(Scheduler):
 
     _schedule = None
     _last_timestamp = None
-    _initial_read = False
+    _initial_read = True
 
     def __init__(self, *args, **kwargs):
         """Initialize the database scheduler."""
@@ -294,11 +294,11 @@ class DatabaseScheduler(Scheduler):
 
     @property
     def schedule(self):
-        update = False
-        if not self._initial_read:
+        initial = update = False
+        if self._initial_read:
             debug('DatabaseScheduler: initial read')
-            update = True
-            self._initial_read = True
+            initial = update = True
+            self._initial_read = False
         elif self.schedule_changed():
             info('DatabaseScheduler: Schedule changed.')
             update = True
@@ -307,7 +307,8 @@ class DatabaseScheduler(Scheduler):
             self.sync()
             self._schedule = self.all_as_schedule()
             # the schedule changed, invalidate the heap in Scheduler.tick
-            self._heap = None
+            if not initial:
+                self._heap = []
             if logger.isEnabledFor(logging.DEBUG):
                 debug('Current schedule:\n%s', '\n'.join(
                     repr(entry) for entry in values(self._schedule)),

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -400,6 +400,12 @@ class test_DatabaseScheduler(SchedulerCase):
         with pytest.raises(RuntimeError):
             self.s.sync()
 
+    def test_update_scheduler_heap_invalidation(self, monkeypatch):
+        # mock "schedule_changed" to always trigger update for
+        # all calls to schedule, as a change may occur at any moment
+        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
+        self.s.tick()
+
 
 @pytest.mark.django_db()
 class test_models(SchedulerCase):


### PR DESCRIPTION
The issue occurs in celery 4.2+ and the included test case reproduces it,
introduced in celery pull celery/celery#4493 and to django-celery-beat in PR #25

- on initial read, return None to make sure we populate heap and old_schedulers
- include (hypothetic) test case where every sync returns an update
- inverse _initial_read condition to be make it clearer

fixes celery/celery#5032