### PR TITLE
raised ValidationError when interval or solar, should be interval and solar

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -325,7 +325,7 @@ class PeriodicTask(models.Model):
             raise ValidationError({
                 'crontab': [err_msg]
             })
-        if self.interval or self.solar:
+        if self.interval and self.solar:
             raise ValidationError({
                 'solar': [err_msg]
             })


### PR DESCRIPTION
updated the validate_unique method on the PeriodicTask model
raise error when interval AND solar
issue #172