### PR TITLE
fix heap being empty after first schedule change

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -194,6 +194,7 @@ class DatabaseScheduler(Scheduler):
     _schedule = None
     _last_timestamp = None
     _initial_read = True
+    _heap_invalidated = False
 
     def __init__(self, *args, **kwargs):
         """Initialize the database scheduler."""
@@ -294,6 +295,12 @@ class DatabaseScheduler(Scheduler):
             )
         self.update_from_dict(entries)
 
+    def schedules_equal(self, *args, **kwargs):
+        if self._heap_invalidated:
+            self._heap_invalidated = False
+            return False
+        return super(Scheduler, self).schedules_equal(*args, **kwargs)
+
     @property
     def schedule(self):
         initial = update = False
@@ -311,6 +318,7 @@ class DatabaseScheduler(Scheduler):
             # the schedule changed, invalidate the heap in Scheduler.tick
             if not initial:
                 self._heap = []
+                self._heap_invalidated = True
             if logger.isEnabledFor(logging.DEBUG):
                 debug('Current schedule:\n%s', '\n'.join(
                     repr(entry) for entry in values(self._schedule)),

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -299,7 +299,7 @@ class DatabaseScheduler(Scheduler):
         if self._heap_invalidated:
             self._heap_invalidated = False
             return False
-        return super(Scheduler, self).schedules_equal(*args, **kwargs)
+        return super(DatabaseScheduler, self).schedules_equal(*args, **kwargs)
 
     @property
     def schedule(self):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -406,6 +406,15 @@ class test_DatabaseScheduler(SchedulerCase):
         monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
         self.s.tick()
 
+    def test_update_scheduler_heap_invalidation_not_to_break_heap(self, monkeypatch):
+        # heap size is constant unless the schedule changes
+        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
+        expected_heap_size = len(self.s.schedule.values())
+        self.s.tick()
+        assert len(self.s._heap) == expected_heap_size
+        self.s.tick()
+        assert len(self.s._heap) == expected_heap_size
+
 
 @pytest.mark.django_db()
 class test_models(SchedulerCase):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -415,6 +415,13 @@ class test_DatabaseScheduler(SchedulerCase):
         self.s.tick()
         assert len(self.s._heap) == expected_heap_size
 
+    def test_scheduler_schedules_equality_on_change(self, monkeypatch):
+        monkeypatch.setattr(self.s, 'schedule_changed', lambda: False)
+        assert self.s.schedules_equal(self.s.schedule, self.s.schedule)
+
+        monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
+        assert not self.s.schedules_equal(self.s.schedule, self.s.schedule)
+
 
 @pytest.mark.django_db()
 class test_models(SchedulerCase):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -406,7 +406,7 @@ class test_DatabaseScheduler(SchedulerCase):
         monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
         self.s.tick()
 
-    def test_update_scheduler_heap_invalidation_not_to_break_heap(self, monkeypatch):
+    def test_heap_size_is_constant(self, monkeypatch):
         # heap size is constant unless the schedule changes
         monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
         expected_heap_size = len(self.s.schedule.values())


### PR DESCRIPTION
fixes #170

If the scheduler receives the change notification when none of the the tasks' fields were changed the heap will be set to empty list and all of the tasks will stop executing (the test in PR shows the heap being empty on second tick after initial read)