### PR TITLE
After changing the PeriodicTask for one-off task we should mark it ch…

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -97,14 +97,14 @@ class ModelEntry(ScheduleEntry):
 
     def is_due(self):
         if not self.model.enabled:
-            return False, 5.0   # 5 second delay for re-enable.
+            return schedules.schedstate(False, 5.0)   # 5 second delay for re-enable.
 
         # START DATE: only run after the `start_time`, if one exists.
         if self.model.start_time is not None:
             if maybe_make_aware(self._default_now()) < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 _, delay = self.schedule.is_due(self.last_run_at)
-                return False, delay  # use original delay for re-check
+                return schedules.schedstate(False, delay)  # use original delay for re-check
 
         # ONE OFF TASK: Disable one off tasks after they've ran once
         if self.model.one_off and self.model.enabled \
@@ -113,7 +113,7 @@ class ModelEntry(ScheduleEntry):
             self.model.total_run_count = 0  # Reset
             self.model.no_changes = False  # Mark the model entry as changed
             self.model.save()
-            return False, None  # Don't recheck
+            return schedules.schedstate(False, None)  # Don't recheck
 
         return self.schedule.is_due(self.last_run_at)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -111,6 +111,7 @@ class ModelEntry(ScheduleEntry):
                 and self.model.total_run_count > 0:
             self.model.enabled = False
             self.model.total_run_count = 0  # Reset
+            self.model.no_changes = False  # Mark the model entry as changed
             self.model.save()
             return False, None  # Don't recheck
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -97,14 +97,16 @@ class ModelEntry(ScheduleEntry):
 
     def is_due(self):
         if not self.model.enabled:
-            return schedules.schedstate(False, 5.0)   # 5 second delay for re-enable.
+            # 5 second delay for re-enable.
+            return schedules.schedstate(False, 5.0)
 
         # START DATE: only run after the `start_time`, if one exists.
         if self.model.start_time is not None:
             if maybe_make_aware(self._default_now()) < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 _, delay = self.schedule.is_due(self.last_run_at)
-                return schedules.schedstate(False, delay)  # use original delay for re-check
+                # use original delay for re-check
+                return schedules.schedstate(False, delay)
 
         # ONE OFF TASK: Disable one off tasks after they've ran once
         if self.model.one_off and self.model.enabled \

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -427,14 +427,14 @@ class test_DatabaseScheduler(SchedulerCase):
         interval = 10
 
         s1 = schedule(timedelta(seconds=interval))
-        m1 = self.create_model_interval(s1, enabled=False)  # return False, 5.0 in is_due
-        m1.last_run_at = self.app.now() - timedelta(seconds=interval+2)
+        m1 = self.create_model_interval(s1, enabled=False)
+        m1.last_run_at = self.app.now() - timedelta(seconds=interval + 2)
         m1.save()
         m1.refresh_from_db()
 
         s2 = schedule(timedelta(seconds=interval))
         m2 = self.create_model_interval(s2, enabled=True)
-        m2.last_run_at = self.app.now() - timedelta(seconds=interval+1)
+        m2.last_run_at = self.app.now() - timedelta(seconds=interval + 1)
         m2.save()
         m2.refresh_from_db()
 


### PR DESCRIPTION
If a PeriodicTask's enabled is set to False, it should be removed from the current schedule or else the is_due method will always return at the first conditions test which is in a bad state. 