### PR TITLE
Add 'name' as a search filter

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -119,6 +119,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
     celery_app = current_app
     list_display = ('__str__', 'enabled', 'interval', 'start_time', 'one_off')
     actions = ('enable_tasks', 'disable_tasks', 'toggle_tasks', 'run_tasks')
+    search_fields = ('name',)
     fieldsets = (
         (None, {
             'fields': ('name', 'regtask', 'task', 'enabled', 'description',),


### PR DESCRIPTION
We are seeing a need to add more search/filter options for django-celery-beat's admin because we have too many tasks. It would be very nice to be able to select many items based on simple search.