### PR TITLE
Remove dependency for 0006_auto_20180210_1226 in 0006_auto_20180322_0932

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ htmlcov/
 coverage.xml
 .eggs/
 .python-version
+venv

--- a/django_celery_beat/migrations/0006_auto_20180322_0932.py
+++ b/django_celery_beat/migrations/0006_auto_20180322_0932.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('django_celery_beat', '0005_add_solarschedule_events_choices'),
-        ('django_celery_beat', '0006_auto_20180210_1226'),
+        # ('django_celery_beat', '0006_auto_20180210_1226'),
     ]
 
     operations = [


### PR DESCRIPTION
We can safely remove dependency for 0006_auto_20180210_1226 in 0006_auto_20180322_0932 to avoid the inconsistency migration exception when upgrade to django-celery-beat 1.3.0