### PR TITLE
make last_run_at tz aware before passing to celery

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -93,12 +93,7 @@ class ModelEntry(ScheduleEntry):
         if not model.last_run_at:
             model.last_run_at = self._default_now()
 
-        last_run_at = model.last_run_at
-
-        if getattr(settings, 'DJANGO_CELERY_BEAT_TZ_AWARE', True):
-            last_run_at = make_aware(last_run_at)
-
-        self.last_run_at = last_run_at
+        self.last_run_at = model.last_run_at
 
     def _disable(self, model):
         model.no_changes = True
@@ -133,7 +128,7 @@ class ModelEntry(ScheduleEntry):
             self.model.save()
             return schedules.schedstate(False, None)  # Don't recheck
 
-        return self.schedule.is_due(self.last_run_at)
+        return self.schedule.is_due(make_aware(self.last_run_at))
 
     def _default_now(self):
         # The PyTZ datetime must be localised for the Django-Celery-Beat

--- a/django_celery_beat/utils.py
+++ b/django_celery_beat/utils.py
@@ -21,6 +21,10 @@ def make_aware(value):
         # then convert to the Django configured timezone.
         default_tz = timezone.get_default_timezone()
         value = timezone.localtime(value, default_tz)
+    else:
+        # naive datetimes are assumed to be in local timezone.
+        if timezone.is_naive(value):
+            value = timezone.make_aware(value, timezone.get_default_timezone())
     return value
 
 


### PR DESCRIPTION
celery always makes times TZ-aware and will wrongly assume they are in UTC, even when the
dates from the django model have an (implicit) non-UTC TZ, like in cases where `USE_TZ=False` and `TIME_ZONE` is set to something other than `UTC`.

this should fix #211 