### PR TITLE
Fix invalid long_description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,13 +215,12 @@ Both the worker and beat services need to be running at the same time.
         $ celery -A [project-name] beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
 
 
-  **OR** you can use the -S (scheduler flag), for more options see ``celery beat --help ``)::
+   **OR** you can use the -S (scheduler flag), for more options see ``celery beat --help``)::
 
             $ celery -A [project-name] beat -l info -S django
 
-
-Also, as an alternative, you can run the two steps above (worker and beat services)
-with only one command (recommended for **development environment only**)::
+   Also, as an alternative, you can run the two steps above (worker and beat services)
+   with only one command (recommended for **development environment only**)::
 
 
     $ celery -A [project-name] worker --beat --scheduler django --loglevel=info


### PR DESCRIPTION
This PR fixes invalid syntax in `README.rst` which will prevent upload to PyPI. Fixes #254.

Before:

```
$ python setup.py sdist bdist_wheel
...
$ twine check dist/*
Checking distribution dist/django_celery_beat-1.4.0-py2.py3-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 218: Warning: Inline literal start-string without end-string.
Checking distribution dist/django-celery-beat-1.4.0.tar.gz: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 218: Warning: Inline literal start-string without end-string.
line 218: Warning: Inline literal start-string without end-string.
```

With this change:

```
$ python setup.py sdist bdist_wheel
...
$ twine check dist/*
Checking distribution dist/django_celery_beat-1.4.0-py2.py3-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
Checking distribution dist/django-celery-beat-1.4.0.tar.gz: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
```