### PR TITLE
Fix pip requirement formatting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps=
     cov: -r{toxinidir}/requirements/test-django111.txt
 
     django111: -r{toxinidir}/requirements/test-django111.txt
-    django21: django>=2.1<2.2
+    django21: django>=2.1,<2.2
     django22: -r{toxinidir}/requirements/test-django22.txt
 
     py{27,py}: -r{toxinidir}/requirements/python2.txt


### PR DESCRIPTION
Tests started failing due to it pulling in django 3.0b by accident, which removes six from django.