### PR TITLE
Fix case where last_run_at=None and CELERY_TIMEZONE!=TIME_ZONE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,19 +258,15 @@ The last command must be executed as a privileged user if
 you are not currently using a virtualenv.
 
 
-After installation, add `django_celery_beat` to Django settings file and migrate.
+After installation, add ``django_celery_beat`` to Django settings file::
 
-settings.py
-```
-INSTALLED_APPS = [
-    ...,
-    'django_celery_beat',
-]
-```
+    INSTALLED_APPS = [
+        ...,
+        'django_celery_beat',
+    ]
 
-```
-python manage.py migrate django_celery_beat
-```
+    python manage.py migrate django_celery_beat
+
 
 Using the development version
 -----------------------------

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -134,7 +134,7 @@ class ModelEntry(ScheduleEntry):
             self.model.save()
             return schedules.schedstate(False, None)  # Don't recheck
 
-        return self.schedule.is_due(make_aware(self.last_run_at))
+        return self.schedule.is_due(make_aware(self.last_run_at).astimezone(self.app.timezone))
 
     def _default_now(self):
         # The PyTZ datetime must be localised for the Django-Celery-Beat

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import math, os
+import math
+import os
 import time
 import pytest
 
@@ -178,7 +179,7 @@ class test_ModelEntry(SchedulerCase):
             del os.environ["TZ"]
         if hasattr(time, "tzset"):
             time.tzset()
-    
+
     @override_settings(
         USE_TZ=False,
         DJANGO_CELERY_BEAT_TZ_AWARE=False,

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-import math
+import math, os
 import time
 import pytest
 
@@ -151,13 +151,18 @@ class test_ModelEntry(SchedulerCase):
         USE_TZ=False,
         DJANGO_CELERY_BEAT_TZ_AWARE=False
     )
+    @pytest.mark.usefixtures('depends_on_current_app')
     @timezone.override('Europe/Berlin')
     @pytest.mark.celery(timezone='Europe/Berlin')
     def test_entry_is_due__no_use_tz(self):
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Berlin"
+        if hasattr(time, "tzset"):
+            time.tzset()
         assert self.app.timezone.zone == 'Europe/Berlin'
 
         # simulate last_run_at from DB - not TZ aware but localtime
-        right_now = timezone.now()
+        right_now = datetime.utcnow()
 
         m = self.create_model_crontab(
             crontab(minute='*/10'),
@@ -167,6 +172,12 @@ class test_ModelEntry(SchedulerCase):
 
         assert e.is_due().is_due is False
         assert e.is_due().next <= 600  # 10 minutes; see above
+        if old_tz is not None:
+            os.environ["TZ"] = old_tz
+        else:
+            del os.environ["TZ"]
+        if hasattr(time, "tzset"):
+            time.tzset()
     
     @override_settings(
         USE_TZ=False,
@@ -174,14 +185,19 @@ class test_ModelEntry(SchedulerCase):
         TIME_ZONE="Europe/Berlin",
         CELERY_TIMEZONE="America/New_York"
     )
+    @pytest.mark.usefixtures('depends_on_current_app')
     @timezone.override('Europe/Berlin')
     @pytest.mark.celery(timezone='America/New_York')
     def test_entry_is_due__celery_timezone_doesnt_match_time_zone(self):
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Berlin"
+        if hasattr(time, "tzset"):
+            time.tzset()
         assert self.app.timezone.zone == 'America/New_York'
 
         # simulate last_run_at all none, doing the same thing that
         # _default_now() would do
-        right_now = timezone.now()
+        right_now = datetime.utcnow()
 
         m = self.create_model_crontab(
             crontab(minute='*/10'),
@@ -191,6 +207,12 @@ class test_ModelEntry(SchedulerCase):
 
         assert e.is_due().is_due is False
         assert e.is_due().next <= 600  # 10 minutes; see above
+        if old_tz is not None:
+            os.environ["TZ"] = old_tz
+        else:
+            del os.environ["TZ"]
+        if hasattr(time, "tzset"):
+            time.tzset()
 
     def test_task_with_start_time(self):
         interval = 10


### PR DESCRIPTION
In this PR, I'd like to fix a case where beat causes celery to misinterpret the hours of a crontab. The exact data scenario is given below. Skimming through the open issues, it's possible that there are other lurking scenarios that could have similar issues, but I'm pretty confident that this PR at least fixes this scenario. The ultimate conclusion is that celery's crontab.is_due must always be given a datetime in terms of CELERY_TIMEZONE, not TIME_ZONE and this change ensures that. 

My analysis of my particular scenario:

With CELERY_TZ_AWARE= False, USE_TZ=False, Django TIMEZONE="UTC", and CELERY_TIMEZONE="Los_Angeles"
If all last_run_at=None:
    django_celery_beat.ModelEntry is_due gets called by beat, and assumes last_run_at=_get_default_now().
        Because the TZ environment variable has been set to django's timezone, UTC, it returns a
        naive object that corresponds to the current time in utc.

    django_celery_beat.ModelEntry.is_due then calls make_aware on this, which just adds the UTC tzinfo to the datetime. (it uses the tz returned by
        django.utils.timezone.get_default_timezone(), which just returns the value of TIMEZONE)
    celery.schedules.crontab.is_due is next called and given this datetime, delegating to remaining_estimate.
    remaining_estimate then calls remaining_delta
    remaining_delta first gets now(), using CELERY_TIMEZONE, returning a tz-aware datetime, with tzinfo=los_angeles.
        It also calls maybe_make_aware on the last_run_ts object, but this function doesn't do anything if the datetime isn't naive
    Finally, remaining_delta compares the hour attribute of last_run_ts (which is in UTC) with the hours attribute of the crontab object, which is in terms of CELERY_TIMEZONE, not settings.TIME_ZONE. Because of this, the hour never matches and the job never fires.


