### PR TITLE
Fix readme.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,19 +258,15 @@ The last command must be executed as a privileged user if
 you are not currently using a virtualenv.
 
 
-After installation, add `django_celery_beat` to Django settings file and migrate.
+After installation, add ``django_celery_beat`` to Django settings file::
 
-settings.py
-```
-INSTALLED_APPS = [
-    ...,
-    'django_celery_beat',
-]
-```
+    INSTALLED_APPS = [
+        ...,
+        'django_celery_beat',
+    ]
 
-```
-python manage.py migrate django_celery_beat
-```
+    python manage.py migrate django_celery_beat
+
 
 Using the development version
 -----------------------------


### PR DESCRIPTION
I think we are hitting a bug in the markdown processing, where triple backticks are not working properly... I got it to work another way here though, so saving this to make the readme show up properly.  

Instead of triple backticks, it now uses double colon and then tabs to do the same thing, which is a copy of things above this section.