### PR TITLE
Fix Typo in Package Metadata

### DIFF
--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 
 __version__ = '1.5.0'
 __author__ = 'Asif Saif Uddin, Ask Solem'
-__contact__ = 'auvipy@gmai.com, ask@celeryproject.org'
+__contact__ = 'auvipy@gmail.com, ask@celeryproject.org'
 __homepage__ = 'https://github.com/celery/django-celery-beat'
 __docformat__ = 'restructuredtext'
 


### PR DESCRIPTION
@auvipy There _are_ MX records for that domain but I still assume this is a typo 😄