### PR TITLE
Don't set last_run_at to datetime.now() on ModelEntry for TZ unaware projects

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -163,9 +163,6 @@ class ModelEntry(ScheduleEntry):
         for field in self.save_fields:
             setattr(obj, field, getattr(self.model, field))
 
-        if not getattr(settings, 'DJANGO_CELERY_BEAT_TZ_AWARE', True):
-            obj.last_run_at = datetime.datetime.now()
-
         obj.save()
 
     @classmethod


### PR DESCRIPTION
I found when restarting celery with beat that our tasks was not starting after restart. I found that if DJANGO_CELERY_BEAT_TZ_AWARE = False last_run_at was updated with datetime.now() which I found wrong as all other places is using _defaultnow() to generate correct datetime with UTC.
Also the code path was different when using DJANGO_CELERY_BEAT_TZ_AWARE = False as it always set last_run_at to current date, while if DJANGO_CELERY_BEAT_TZ_AWARE = True the models last_run_at was used.

This PR removes this behaviour and adds a test to prove it.
