### PR TITLE
Improve PeriodicTask.validate_unique() function.

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -533,21 +533,24 @@ class PeriodicTask(models.Model):
 
         schedule_types = ['interval', 'crontab', 'solar', 'clocked']
         selected_schedule_types = [s for s in schedule_types
-                                   if getattr(self, s)]
+                                   if getattr(self, s, None)]
 
         if len(selected_schedule_types) == 0:
-            raise ValidationError({
-                'interval': [
-                    'One of clocked, interval, crontab, or solar must be set.'
-                ]
-            })
+            err_msg = \
+                'One of clocked, interval, crontab, or solar must be set.'
+            error_info = {
+                schedule_type: [err_msg]
+                for schedule_type in schedule_types
+            }
+            raise ValidationError(error_info)
 
-        err_msg = 'Only one of clocked, interval, crontab, '\
-            'or solar must be set'
-        if len(selected_schedule_types) > 1:
-            error_info = {}
-            for selected_schedule_type in selected_schedule_types:
-                error_info[selected_schedule_type] = [err_msg]
+        elif len(selected_schedule_types) > 1:
+            err_msg = \
+                'Only one of clocked, interval, crontab, or solar must be set'
+            error_info = {
+                selected_schedule_type: [err_msg]
+                for selected_schedule_type in selected_schedule_types
+            }
             raise ValidationError(error_info)
 
         # clocked must be one off task


### PR DESCRIPTION
I've overridden the default PeriodicTaskAdmin to remove "interval" field from the form, because I don't want the users to use this option.
But when I create a PeriodicTask: an AttributeError is raised in [django_celery_beat/models.py#L535](https://github.com/celery/django-celery-beat/blob/master/django_celery_beat/models.py#L535)
```python
selected_schedule_types = [s for s in schedule_types if getattr(self, s)]
```

To avoid this error, instead of removing I just hide the field by setting a HiddenInput widget. With this widget the "interval" is not displayed in the form and the error is not raised, but...

if I select no schedule: a ValidationError is raised (as expected), but the message error doesn't show up because the error is linked to "interval" (which is hidden)
```python
if len(selected_schedule_types) == 0:
    raise ValidationError({
        'interval': [
            'One of clocked, interval, crontab, or solar must be set.'
        ]
    })
```

This PR makes `PeriodicTask.validate_unique()` work in both scenarios:
- the field is removed, by adding a default None in `getattr`
```python
selected_schedule_types = [s for s in schedule_types if getattr(self, s, None)]
```

- the field is hidden, by linking the error msg to all schedule fields:
```python
if len(selected_schedule_types) == 0:
    err_msg = \
        'One of clocked, interval, crontab, or solar must be set.'
    error_info = {
        schedule_type: [err_msg]
        for schedule_type in schedule_types
    }
    raise ValidationError(error_info)
```
