### PR TITLE
If no schedule is selected, raise a non-field error.

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -536,11 +536,10 @@ class PeriodicTask(models.Model):
                                    if getattr(self, s)]
 
         if len(selected_schedule_types) == 0:
-            raise ValidationError({
-                'interval': [
-                    'One of clocked, interval, crontab, or solar must be set.'
-                ]
-            })
+            raise ValidationError(
+                'One of clocked, interval, crontab, or solar '
+                'must be set.'
+            )
 
         err_msg = 'Only one of clocked, interval, crontab, '\
             'or solar must be set'


### PR DESCRIPTION
Suggested change:
In PeriodicTask, if no schedule is selected, raise a non-field error instead of an error bound to the "interval" field.

Reason:
Binding the error to "interval", and not to "crontab", "solar" or "clocked", is arbitrary.
Moreover, if a custom form doesn't have the "interval" field, it will raise the following error:

```python
~/.virtualenvs/lr/lib/python3.8/site-packages/django/forms/forms.py in add_error(self, field, error)
    350             if field not in self.errors:
    351                 if field != NON_FIELD_ERRORS and field not in self.fields:
--> 352                     raise ValueError(
    353                         "'%s' has no field named '%s'." % (self.__class__.__name__, field))
    354                 if field == NON_FIELD_ERRORS:
ValueError: 'MyPeriodicTaskForm' has no field named 'interval'.
```

