### PR TITLE
If the clocked schedule is tied to a one off task, don't disable it. …

### DIFF
--- a/django_celery_beat/clockedschedule.py
+++ b/django_celery_beat/clockedschedule.py
@@ -33,7 +33,7 @@ class clocked(schedules.BaseSchedule):
         rem_delta = self.remaining_estimate(None)
         remaining_s = max(rem_delta.total_seconds(), 0)
         if remaining_s == 0:
-            if self.model:
+            if self.model and not self.model.periodictask_set.filter(one_off=True).exists():
                 self.model.enabled = False
                 self.model.save()
             return schedstate(is_due=True, next=None)


### PR DESCRIPTION
As far as I can tell there is no reason to disable the clock, sine that the task will get disabled on the next run.