### PR TITLE
Fix PostgreSQL docker-compose setup, and expose rabbit for testing.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,10 @@ services:
       - './django_celery_beat/:/app/django_celery_beat/'
 
   rabbit:
-      image: rabbitmq
-
+    image: rabbitmq
+    ports:
+        - "5672:5672"
   postgres:
     image: postgres
+    environment:
+        POSTGRES_PASSWORD: s3cr3t

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -29,7 +29,7 @@ RUN django-admin startproject mysite
 
 WORKDIR /mysite/
 
-RUN echo 'DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "postgres", "USER": "postgres", "HOST": "postgres", "PORT": 5432}}' >> mysite/settings.py
+RUN echo 'DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "postgres", "USER": "postgres","PASSWORD": "s3cr3t", "HOST": "postgres", "PORT": 5432}}' >> mysite/settings.py
 RUN echo 'ALLOWED_HOSTS = ["*"]' >> mysite/settings.py
 RUN echo 'INSTALLED_APPS += ("django_celery_beat", )' >> mysite/settings.py
 RUN echo 'INSTALLED_APPS += ("django_createsuperuserwithpassword", )' >> mysite/settings.py


### PR DESCRIPTION
- New PostgreSQL images require a password.
- Expose rabbit, allowing for `docker-compose up rabbit` and `python setup.py test`