### PR TITLE
Keep meta data around task, even after disabled.

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -133,7 +133,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
         }),
         ('Schedule', {
             'fields': ('interval', 'crontab', 'solar', 'clocked',
-                       'start_time', 'last_run_at', 'one_off'),
+                       'start_time', 'last_run_at','total_run_count', 'one_off'),
             'classes': ('extrapretty', 'wide'),
         }),
         ('Arguments', {
@@ -148,6 +148,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
     )
     readonly_fields = (
         'last_run_at',
+        'total_run_count'
     )
 
     def changelist_view(self, request, extra_context=None):

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -574,8 +574,6 @@ class PeriodicTask(models.Model):
         self.routing_key = self.routing_key or None
         self.queue = self.queue or None
         self.headers = self.headers or None
-        if not self.enabled:
-            self.last_run_at = None
         self._clean_expires()
         self.validate_unique()
         super(PeriodicTask, self).save(*args, **kwargs)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -125,7 +125,6 @@ class ModelEntry(ScheduleEntry):
         if self.model.one_off and self.model.enabled \
                 and self.model.total_run_count > 0:
             self.model.enabled = False
-            self.model.total_run_count = 0  # Reset
             self.model.no_changes = False  # Mark the model entry as changed
             self.model.save()
             return schedules.schedstate(False, None)  # Don't recheck


### PR DESCRIPTION
- added `total_run_count` to the admin
- don't clear out last_run_at, on disabling a task.
- don't clear out total_run_count on one of tasks.