### PR TITLE
Follow deprecation of celery.utils.encoding

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -8,7 +8,7 @@ from multiprocessing.util import Finalize
 from celery import current_app
 from celery import schedules
 from celery.beat import Scheduler, ScheduleEntry
-from celery.utils.encoding import safe_str, safe_repr
+from kombu.utils.encoding import safe_str, safe_repr
 from celery.utils.log import get_logger
 from celery.utils.time import maybe_make_aware
 from kombu.utils.json import dumps, loads


### PR DESCRIPTION
See
https://github.com/celery/celery/commit/c0697c84c4cafee2df1254fc6a19792cdd7c3993#diff-72b216a32140e33416e4363bd31e87fd
for more information.

FYI: I started this because I wanted to upgrade to Celery 5.0.0. I am now dropping this as I lack some time, but it might still be useful to someone.