### PR TITLE
Pin requirements versions to fix build and add 2.1.0 changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 dist: xenial
 cache: false
 before_install:

--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,19 @@
  Change history
 ================
 
+2.1.0
+=====
+:release-date: 
+:release-by: 
+- Fix string representation of CrontabSchedule, so it matches UNIX CRON expression format (#318)
+- If no schedule is selected in PeriodicTask form, raise a non-field error instead of an error bounded to the `interval` field (#327)
+- Fix some Spanish translations (#339)
+- Log "Writing entries..." message as DEBUG instead of INFO (#342)
+- Use CELERY_TIMEZONE setting as `CrontabSchedule.timezone` default instead of UTC (#346)
+- Fix bug in ClockedSchedule that made the schedule stuck after a clocked task was executed. The `enabled` field of ClockedSchedule has been dropped (#341)
+- Drop support for Python < 3.6 (#368)
+- Add support for Celery 5 and Django 3.1 (#368)
+
 2.0.0
 =====
 :release-date: 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,2 +1,3 @@
+celery>=4.4,<6.0
 django-timezone-field>=4.0,<5.0
 python-crontab>=2.3.4

--- a/requirements/python3.txt
+++ b/requirements/python3.txt
@@ -1,3 +1,0 @@
-# for python3, install latest stuff
-https://github.com/celery/celery/zipball/master#egg=celery
-https://github.com/celery/kombu/zipball/master#egg=kombu

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,1 @@
-celery>=4.4,<6.0
-Django>=2.2
+Django>=2.2,<4.0

--- a/requirements/test-django.txt
+++ b/requirements/test-django.txt
@@ -1,1 +1,1 @@
-django
+Django>=2.2,<4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 case>=1.3.1
-pytest-django
+pytest-django>=2.2,<4.0
 pytz>dev
 pytest<4.0.0
 pytest-timeout

--- a/t/unit/test_admin.py
+++ b/t/unit/test_admin.py
@@ -84,7 +84,7 @@ class ValidateUniqueTests(TestCase):
     def test_validate_unique_raises_if_schedule_not_set(self):
         with self.assertRaises(ValidationError) as cm:
             PeriodicTask(name='task0').validate_unique()
-        self.assertEquals(
+        self.assertEqual(
             cm.exception.args[0],
             'One of clocked, interval, crontab, or solar must be set.',
         )
@@ -106,9 +106,9 @@ class ValidateUniqueTests(TestCase):
             with self.assertRaises(ValidationError) as cm:
                 PeriodicTask(name=name, **options_dict).validate_unique()
             errors = cm.exception.args[0]
-            self.assertEquals(errors.keys(), options_dict.keys())
+            self.assertEqual(errors.keys(), options_dict.keys())
             for error_msg in errors.values():
-                self.assertEquals(error_msg, [expected_error_msg])
+                self.assertEqual(error_msg, [expected_error_msg])
 
     def test_validate_unique_not_raises(self):
         PeriodicTask(crontab=CrontabSchedule()).validate_unique()

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,6 @@ deps=
     django30: -r{toxinidir}/requirements/test-django30.txt
     django31: -r{toxinidir}/requirements/test-django31.txt
 
-    py{36,37,38,py3}: -r{toxinidir}/requirements/python3.txt
-
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
 sitepackages = False


### PR DESCRIPTION
Since the release of pytest-django==4, unit tests fail. I've added `pytest-django>=2.2,<4.0` to the requirements to fix it.
This PR will fix the build of master branch, and the unit test failures of #361 and #371 .

I've also fixed two deprecation warnings: `assertEquals` in some unit tests and `sudo` in travis.yml.

Commit added with 2.1.0 changelog (fixes #374 ).