### PR TITLE
Fix breakage caused by change in django-timezone-field

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -57,7 +57,8 @@ def crontab_schedule_celery_timezone():
     except AttributeError:
         return 'UTC'
     return CELERY_TIMEZONE if CELERY_TIMEZONE in [
-        choice[0].zone for choice in timezone_field.TimeZoneField.CHOICES
+        choice[0].zone for choice in timezone_field.
+        TimeZoneField.default_choices
     ] else 'UTC'
 
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 celery>=4.4,<6.0
-django-timezone-field>=4.0,<5.0
+django-timezone-field>=4.1.0,<5.0
 python-crontab>=2.3.4

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -60,7 +60,8 @@ class MigrationTests(TestCase):
 
 
 class CrontabScheduleTestCase(TestCase):
-    FIRST_VALID_TIMEZONE = timezone_field.TimeZoneField.CHOICES[0][0].zone
+    FIRST_VALID_TIMEZONE = timezone_field.\
+        TimeZoneField.default_choices[0][0].zone
 
     def test_default_timezone_without_settings_config(self):
         assert crontab_schedule_celery_timezone() == "UTC"


### PR DESCRIPTION
In https://github.com/mfogel/django-timezone-field/commit/0c6a6bae8e9c36c3d236e47eff136b085a4639df the `CHOICES` property was removed, it was replaced with two new fields `default_tzs` and `default_choices`. The latter of the two is the same choices as before and so we just use that now instead.

Fixes #377 
