### PR TITLE
Do not blindly delete duplicate schedules

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -122,8 +122,9 @@ class SolarSchedule(models.Model):
         except cls.DoesNotExist:
             return cls(**spec)
         except MultipleObjectsReturned:
-            cls.objects.filter(**spec).delete()
-            return cls(**spec)
+            # unique_together constraint should not permit reaching this code,
+            # but just in case, we return the first schedule found
+            return cls.objects.filter(**spec).first()
 
     def __str__(self):
         return '{0} ({1}, {2})'.format(
@@ -183,8 +184,7 @@ class IntervalSchedule(models.Model):
         except cls.DoesNotExist:
             return cls(every=every, period=period)
         except MultipleObjectsReturned:
-            cls.objects.filter(every=every, period=period).delete()
-            return cls(every=every, period=period)
+            return cls.objects.filter(every=every, period=period).first()
 
     def __str__(self):
         readable_period = None
@@ -236,8 +236,7 @@ class ClockedSchedule(models.Model):
         except cls.DoesNotExist:
             return cls(**spec)
         except MultipleObjectsReturned:
-            cls.objects.filter(**spec).delete()
-            return cls(**spec)
+            return cls.objects.filter(**spec).first()
 
 
 class CrontabSchedule(models.Model):
@@ -350,8 +349,7 @@ class CrontabSchedule(models.Model):
         except cls.DoesNotExist:
             return cls(**spec)
         except MultipleObjectsReturned:
-            cls.objects.filter(**spec).delete()
-            return cls(**spec)
+            return cls.objects.filter(**spec).first()
 
 
 class PeriodicTasks(models.Model):

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -117,14 +117,13 @@ class SolarSchedule(models.Model):
         spec = {'event': schedule.event,
                 'latitude': schedule.lat,
                 'longitude': schedule.lon}
+
+        # we do not check for MultipleObjectsReturned exception here because
+        # the unique_together constraint safely prevents from duplicates
         try:
             return cls.objects.get(**spec)
         except cls.DoesNotExist:
             return cls(**spec)
-        except MultipleObjectsReturned:
-            # unique_together constraint should not permit reaching this code,
-            # but just in case, we return the first schedule found
-            return cls.objects.filter(**spec).first()
 
     def __str__(self):
         return '{0} ({1}, {2})'.format(

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -80,17 +80,25 @@ class CrontabScheduleTestCase(TestCase):
 
     def test_duplicate_schedules(self):
         # See: https://github.com/celery/django-celery-beat/issues/322
+        kwargs = {
+            "minute": "*",
+            "hour": "4",
+            "day_of_week": "*",
+            "day_of_month": "*",
+            "month_of_year": "*",
+            "day_of_week": "*",
+        }
         # create 2 duplicates schedules
-        sched1 = CrontabSchedule.objects.create(hour="4")
-        CrontabSchedule.objects.create(hour="4")
-        self.assertEqual(CrontabSchedule.objects.count(), 2)
+        sched1 = CrontabSchedule.objects.create(**kwargs)
+        CrontabSchedule.objects.create(**kwargs)
+        self.assertEqual(CrontabSchedule.objects.filter(**kwargs).count(), 2)
         # try to create a duplicate CrontabSchedule from a celery schedule
         schedule = schedules.crontab(hour="4")
         sched3 = CrontabSchedule.from_schedule(schedule)
         # the schedule should be the first of the 2 previous duplicates
         self.assertEqual(sched3, sched1)
         # and the duplicates should not be deleted !
-        self.assertEqual(CrontabSchedule.objects.count(), 2)
+        self.assertEqual(CrontabSchedule.objects.filter(**kwargs).count(), 2)
 
 
 class SolarScheduleTestCase(TestCase):
@@ -132,14 +140,14 @@ class IntervalScheduleTestCase(TestCase):
         # create 2 duplicates schedules
         sched1 = IntervalSchedule.objects.create(**kwargs)
         IntervalSchedule.objects.create(**kwargs)
-        self.assertEqual(IntervalSchedule.objects.count(), 2)
+        self.assertEqual(IntervalSchedule.objects.filter(**kwargs).count(), 2)
         # try to create a duplicate IntervalSchedule from a celery schedule
         schedule = schedules.schedule(run_every=1.0)
         sched3 = IntervalSchedule.from_schedule(schedule)
         # the schedule should be the first of the 2 previous duplicates
         self.assertEqual(sched3, sched1)
         # and the duplicates should not be deleted !
-        self.assertEqual(IntervalSchedule.objects.count(), 2)
+        self.assertEqual(IntervalSchedule.objects.filter(**kwargs).count(), 2)
 
 
 class ClockedScheduleTestCase(TestCase):
@@ -156,4 +164,6 @@ class ClockedScheduleTestCase(TestCase):
         # the schedule should be the first of the 2 previous duplicates
         self.assertEqual(sched3, sched1)
         # and the duplicates should not be deleted !
-        self.assertEqual(ClockedSchedule.objects.count(), 2)
+        self.assertEqual(
+            ClockedSchedule.objects.filter(clocked_time=d).count(), 2
+        )

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -126,11 +126,6 @@ class SolarScheduleTestCase(TestCase):
         for event_choice in event_choices_values:
             assert event_choice in schedules.solar._all_events
 
-    def test_duplicate_schedules(self):
-        # Duplicates cannot be tested for solar schedules because of the
-        # unique constraints in the SolarSchedule model
-        pass
-
 
 class IntervalScheduleTestCase(TestCase):
 

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -82,7 +82,7 @@ class CrontabScheduleTestCase(TestCase):
         # See: https://github.com/celery/django-celery-beat/issues/322
         # create 2 duplicates schedules
         sched1 = CrontabSchedule.objects.create(hour="4")
-        sched2 = CrontabSchedule.objects.create(hour="4")
+        CrontabSchedule.objects.create(hour="4")
         self.assertEqual(CrontabSchedule.objects.count(), 2)
         # try to create a duplicate CrontabSchedule from a celery schedule
         schedule = schedules.crontab(hour="4")
@@ -131,7 +131,7 @@ class IntervalScheduleTestCase(TestCase):
         kwargs = {'every': 1, 'period': IntervalSchedule.SECONDS}
         # create 2 duplicates schedules
         sched1 = IntervalSchedule.objects.create(**kwargs)
-        sched2 = IntervalSchedule.objects.create(**kwargs)
+        IntervalSchedule.objects.create(**kwargs)
         self.assertEqual(IntervalSchedule.objects.count(), 2)
         # try to create a duplicate IntervalSchedule from a celery schedule
         schedule = schedules.schedule(run_every=1.0)


### PR DESCRIPTION
Because there are no unique constraints on schedule models (except for
SolarSchedule), schedules tables can contain duplicates, those
duplicate schedules should not be blindly deleted when encountered
because they can be linked to existing tasks and would cause the tasks
to be also deleted (on delete cascade).

Instead we now just return the first duplicate found, just to avoid
creating further duplicates.

This fixes issue #322.