### PR TITLE
Fix default_app_config deprecation

### DIFF
--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -6,6 +6,8 @@ import re
 
 from collections import namedtuple
 
+import django
+
 __version__ = '2.2.0'
 __author__ = 'Asif Saif Uddin, Ask Solem'
 __contact__ = 'auvipy@gmail.com, ask@celeryproject.org'
@@ -29,4 +31,5 @@ del(re)
 
 __all__ = []
 
-default_app_config = 'django_celery_beat.apps.BeatConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'django_celery_beat.apps.BeatConfig'


### PR DESCRIPTION
Django 3.2 automatically detects AppConfig and therefore this setting is no longer required.

https://docs.djangoproject.com/en/dev/releases/3.2/#automatic-appconfig-discovery