### PR TITLE
feat: add periodic_task_name in favor of  celery/django-celery-results#261

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -201,7 +201,8 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
         tasks = [(self.celery_app.tasks.get(task.task),
                   loads(task.args),
                   loads(task.kwargs),
-                  task.queue)
+                  task.queue,
+                  task.name)
                  for task in queryset]
 
         if any(t[0] is None for t in tasks):
@@ -219,10 +220,10 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             )
             return
 
-        task_ids = [task.apply_async(args=args, kwargs=kwargs, queue=queue)
+        task_ids = [task.apply_async(args=args, kwargs=kwargs, queue=queue, periodic_task_name=periodic_task_name)
                     if queue and len(queue)
-                    else task.apply_async(args=args, kwargs=kwargs)
-                    for task, args, kwargs, queue in tasks]
+                    else task.apply_async(args=args, kwargs=kwargs, periodic_task_name=periodic_task_name)
+                    for task, args, kwargs, queue, periodic_task_name in tasks]
         tasks_run = len(task_ids)
         self.message_user(
             request,

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -85,6 +85,7 @@ class ModelEntry(ScheduleEntry):
             self.options['expires'] = getattr(model, 'expires_')
 
         self.options['headers'] = loads(model.headers or '{}')
+        self.options['periodic_task_name'] = model.name
 
         self.total_run_count = model.total_run_count
         self.model = model

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -231,4 +231,25 @@ Working with django-celery-results
 -----------------------------------
 
 Now you can store PeriodicTask.name to django-celery-results (TaskResult.periodic_task_name).
-(more details here: https://github.com/celery/django-celery-beat/pull/477, https://github.com/celery/django-celery-results/pull/261)
+
+Suppose we have two periodic tasks, their schedules are different, but the tasks are the same.
+
++-----------+------------------+------+---------------+
+|   name    |       task       | args |   schedule    |
++===========+==================+======+===============+
+| schedule1 | some.celery.task | (1,) | every hour    |
+| schedule2 | some.celery.task | (2,) | every 2 hours |
++-----------+------------------+------+---------------+
+
+Now you can distinguish the source of the task from the results by the `periodic_task_name` field.
+
++--------+------------------+--------------------+
+|   id   |    task_name     | periodic_task_name |
++========+==================+====================+
+| uuid1  | some.celery.task | schedule1          |
+| uuid2  | some.celery.task | schedule1          |
+| uuid3  | some.celery.task | schedule2          |
+| uuid4  | some.celery.task | schedule2          |
++--------+------------------+--------------------+
+
+(more technical details here: https://github.com/celery/django-celery-beat/pull/477, https://github.com/celery/django-celery-results/pull/261)

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -153,7 +153,7 @@ Example creating crontab-based periodic task
 
 A crontab schedule has the fields: ``minute``, ``hour``, ``day_of_week``,
 ``day_of_month`` and ``month_of_year`, so if you want the equivalent
-of a ``30 * * * *`` (execute at 30 minutes past the hour every hour) crontab 
+of a ``30 * * * *`` (execute at 30 minutes past the hour every hour) crontab
 entry you specify::
 
     >>> from django_celery_beat.models import CrontabSchedule, PeriodicTask
@@ -210,9 +210,9 @@ Both the worker and beat services need to be running at the same time.
   **OR** you can use the -S (scheduler flag), for more options see ``celery beat --help``)::
 
             $ celery -A [project-name] beat -l info -S django
-            
+
   **OR** you can set the scheduler through Django's settings::
-  
+
             CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 
 
@@ -224,3 +224,11 @@ with only one command (recommended for **development environment only**)::
 
 
 3. Now you can add and manage your periodic tasks from the Django Admin interface.
+
+
+
+Working with django-celery-results
+-----------------------------------
+
+Now you can store PeriodicTask.name to django-celery-results (TaskResult.periodic_task_name).
+(more details here: https://github.com/celery/django-celery-beat/pull/477, https://github.com/celery/django-celery-results/pull/261)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -131,6 +131,7 @@ class test_ModelEntry(SchedulerCase):
         assert e.options['routing_key'] == 'cpu'
         assert e.options['priority'] == 1
         assert e.options['headers'] == {'_schema_name': 'foobar'}
+        assert e.options['periodic_task_name'] == m.name
 
         right_now = self.app.now()
         m2 = self.create_model_interval(


### PR DESCRIPTION
celery/django-celery-results#261


Now you can store PeriodicTask.name to django-celery-results (TaskResult.periodic_task_name).

Suppose we have two periodic tasks, their schedules are different, but the tasks are the same.


|   name    |       task       | args |   schedule    |
|-----------|------------------|------|---------------|
| schedule1 | some.celery.task | (1,) | every hour    |
| schedule2 | some.celery.task | (2,) | every 2 hours |


Now you can distinguish the source of the task from the results by the `periodic_task_name` field.


|  id   |    task_name     | periodic_task_name |
|-------|------------------|--------------------|
| uuid1 | some.celery.task | schedule1          |
| uuid2 | some.celery.task | schedule1          |
| uuid3 | some.celery.task | schedule2          |
| uuid4 | some.celery.task | schedule2          |


celery beat will add PeriodicTask.name to requests when scheduled by database or manually scheduled by admin panel.
