### PR TITLE
Change last_run_at=None when using disable tasks admin action

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Grégoire Cachet <gregoire@audacy.fr>
 Hari <haridara@gmail.com>
 Idan Zalzberg <idanzalz@gmail.com>
 Ionel Maries Cristian <ionel.mc@gmail.com>
+Jaeyoung Heo <jay.jaeyoung@gmail.com>
 Jannis Leidel <jannis@leidel.info>
 Jason Baker <amnorvend@gmail.com>
 Jay States <jstates@based.ca>

--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,14 @@
  Change history
 ================
 
+2.3.0
+=====
+:release-date:
+:release-by:
+
+- Admin "disable_tasks" action also updates PeriodicTask's last_run_at field
+
+
 2.2.1
 =====
 :release-date: 2021-07-02 11:15 a.m. UTC+6:00
@@ -30,7 +38,7 @@
 
 2.1.0
 =====
-:release-date: 
+:release-date:
 :release-by: Asif Saif Uddin
 - Fix string representation of CrontabSchedule, so it matches UNIX CRON expression format (#318)
 - If no schedule is selected in PeriodicTask form, raise a non-field error instead of an error bounded to the `interval` field (#327)

--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -179,7 +179,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
     enable_tasks.short_description = _('Enable selected tasks')
 
     def disable_tasks(self, request, queryset):
-        rows_updated = queryset.update(enabled=False)
+        rows_updated = queryset.update(enabled=False, last_run_at=None)
         PeriodicTasks.update_changed()
         self._message_user_about_update(request, rows_updated, 'disabled')
     disable_tasks.short_description = _('Disable selected tasks')

--- a/t/unit/test_admin.py
+++ b/t/unit/test_admin.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
-
 import pytest
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from itertools import combinations
+from unittest import mock
 
 from django_celery_beat.admin import PeriodicTaskAdmin
 from django_celery_beat.models import \
@@ -128,9 +128,8 @@ class DisableTasksTest(TestCase):
         cls.interval_schedule = IntervalSchedule.objects.create(every=10,
                                                                 period=DAYS)
 
-    @patch(
-        'django_celery_beat.admin.PeriodicTaskAdmin._message_user_about_update'
-    )
+    @mock.patch('django_celery_beat.admin.PeriodicTaskAdmin.'
+                '_message_user_about_update')
     def test_disable_tasks(self, mock_message_user):
         PeriodicTask.objects.create(name='name1', task='task1', enabled=True,
                                     interval=self.interval_schedule)


### PR DESCRIPTION
PeriodicTask model's save method implements that when disabling task, it changes its `last_run_at` field to None.

```
# models.py
if not self.enabled:
    self.last_run_at = None
```

But `disable_tasks` in PeriodicTaskAdmin action. does not change periodic task's `last_run_at` attribute.

```
# admin.py
def disable_tasks(self, request, queryset):
    rows_updated = queryset.update(enabled=False)
    PeriodicTasks.update_changed()
    self._message_user_about_update(request, rows_updated, 'disabled')
disable_tasks.short_description = _('Disable selected tasks')
```

Due to this behavior, Even if we disable some tasks using action, tasks runs immediatey as soon as task enabled.

To fix this issue, I suggest change `last_run_at` attribute to None when disable_tasks.

Thanks!