### PR TITLE
Fix line too long lint error

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -220,10 +220,14 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             )
             return
 
-        task_ids = [task.apply_async(args=args, kwargs=kwargs, queue=queue, periodic_task_name=periodic_task_name)
-                    if queue and len(queue)
-                    else task.apply_async(args=args, kwargs=kwargs, periodic_task_name=periodic_task_name)
-                    for task, args, kwargs, queue, periodic_task_name in tasks]
+        task_ids = [
+            task.apply_async(args=args, kwargs=kwargs, queue=queue,
+                             periodic_task_name=periodic_task_name)
+            if queue and len(queue)
+            else task.apply_async(args=args, kwargs=kwargs,
+                                  periodic_task_name=periodic_task_name)
+            for task, args, kwargs, queue, periodic_task_name in tasks
+        ]
         tasks_run = len(task_ids)
         self.message_user(
             request,


### PR DESCRIPTION
Found some lint errors.

<img width="541" alt="Screen Shot 2022-01-24 at 8 02 56 PM" src="https://user-images.githubusercontent.com/13049936/150771368-e29de6a3-9be8-48ba-a6d9-6a9143f8ed33.png">
 
I guess, this project's intended line length would be 79 ( as PEP8 suggests )

Thanks