### PR TITLE
Remove duplicated translation of "Enabled"

### DIFF
--- a/django_celery_beat/locale/fr/LC_MESSAGES/django.po
+++ b/django_celery_beat/locale/fr/LC_MESSAGES/django.po
@@ -229,10 +229,6 @@ msgstr "Horaire"
 msgid "Run the task at clocked time"
 msgstr "Démarre la tâche à l'horaire définie"
 
-#: django_celery_beat/models.py:216 django_celery_beat/models.py:516
-msgid "Enabled"
-msgstr "Activée"
-
 #: django_celery_beat/models.py:217 django_celery_beat/models.py:517
 msgid "Set to False to disable the schedule"
 msgstr "Mettre à Faux pour désactiver la planification"


### PR DESCRIPTION
while locale message compile using `python manage.py compilemessages`
Command complains about french locale.

<img width="999" alt="Screen Shot 2022-01-24 at 8 45 20 PM" src="https://user-images.githubusercontent.com/13049936/150777446-27fda8ca-8589-4c7d-9ff7-805dd843a4b1.png">

I found it `msgid="Enabled"` has defined twice!
So I removed old one. and now compile works well.

Thanks