### PR TITLE
Replace pytz with zoneinfo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Important Warning about Time Zones
 
 
 
-.. note:: 
+.. note::
    This will reset the state as if the periodic tasks have never run before.
 
 
@@ -95,7 +95,7 @@ create the interval object:
 .. code-block:: Python
 
         >>> from django_celery_beat.models import PeriodicTask, IntervalSchedule
-        
+
         # executes every 10 seconds.
         >>> schedule, created = IntervalSchedule.objects.get_or_create(
         ...     every=10,
@@ -181,7 +181,7 @@ of a ``30 * * * *`` (execute every 30 minutes) crontab entry you specify:
         ...     day_of_week='*',
         ...     day_of_month='*',
         ...     month_of_year='*',
-        ...     timezone=pytz.timezone('Canada/Pacific')
+        ...     timezone=zoneinfo.ZoneInfo('Canada/Pacific')
         ... )
 
 The crontab schedule is linked to a specific timezone using the 'timezone' input parameter.
@@ -288,7 +288,7 @@ After installation, add ``django_celery_beat`` to Django's settings module:
 Run the ``django_celery_beat`` migrations using:
 
 .. code-block:: bash
-    
+
         $ python manage.py migrate django_celery_beat
 
 

--- a/django_celery_beat/tzcrontab.py
+++ b/django_celery_beat/tzcrontab.py
@@ -2,8 +2,7 @@
 from celery import schedules
 
 from collections import namedtuple
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 
 schedstate = namedtuple('schedstate', ('is_due', 'next'))
@@ -14,7 +13,7 @@ class TzAwareCrontab(schedules.crontab):
 
     def __init__(
             self, minute='*', hour='*', day_of_week='*',
-            day_of_month='*', month_of_year='*', tz=pytz.utc, app=None
+            day_of_month='*', month_of_year='*', tz=timezone.utc, app=None
     ):
         """Overwrite Crontab constructor to include a timezone argument."""
         self.tz = tz
@@ -28,9 +27,7 @@ class TzAwareCrontab(schedules.crontab):
         )
 
     def nowfunc(self):
-        return self.tz.normalize(
-            pytz.utc.localize(datetime.utcnow())
-        )
+        return datetime.utcnow().astimezone(self.tz)
 
     def is_due(self, last_run_at):
         """Calculate when the next run will take place.

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,1 +1,4 @@
 Django>=2.2,<4.1
+# zoneinfo is preset in Python 3.9 onwards
+# Django 4.x onwards uses zoneinfo by default but not the tzdata
+backports.zoneinfo[tzdata]==0.2.1; python_version < '3.9'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 case>=1.3.1
 pytest-django>=2.2,<4.0
-pytz>dev
 pytest<4.0.0
 pytest-timeout
 ephem


### PR DESCRIPTION
Replace pytz with zoneinfo, which is part of Python 3.9+ and the default timezone implementation for Django 4.x onwards