### PR TITLE
Documentation improvements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
 sphinx:
    configuration: docs/conf.py
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+sphinx:
+   configuration: docs/conf.py
+python:
+   install:
+   - requirements: requirements/docs.txt

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -57,9 +57,9 @@ def cronexp(field):
 
 
 def crontab_schedule_celery_timezone():
-    """Return timezone string from Django settings `CELERY_TIMEZONE` variable.
+    """Return timezone string from Django settings ``CELERY_TIMEZONE`` variable.
 
-    If is not defined or is not a valid timezone, return `"UTC"` instead.
+    If is not defined or is not a valid timezone, return ``"UTC"`` instead.
     """
     try:
         CELERY_TIMEZONE = getattr(
@@ -76,7 +76,8 @@ class SolarSchedule(models.Model):
     """Schedule following astronomical patterns.
 
     Example: to run every sunrise in New York City:
-    event='sunrise', latitude=40.7128, longitude=74.0060
+
+    >>> event='sunrise', latitude=40.7128, longitude=74.0060
     """
 
     event = models.CharField(
@@ -136,8 +137,9 @@ class SolarSchedule(models.Model):
 class IntervalSchedule(models.Model):
     """Schedule executing on a regular interval.
 
-    Example: execute every 2 days
-    every=2, period=DAYS
+    Example: execute every 2 days:
+
+    >>> every=2, period=DAYS
     """
 
     DAYS = DAYS
@@ -241,9 +243,10 @@ class ClockedSchedule(models.Model):
 class CrontabSchedule(models.Model):
     """Timezone Aware Crontab-like schedule.
 
-    Example:  Run every hour at 0 minutes for days of month 10-15
-    minute="0", hour="*", day_of_week="*",
-    day_of_month="10-15", month_of_year="*"
+    Example:  Run every hour at 0 minutes for days of month 10-15:
+
+    >>> minute="0", hour="*", day_of_week="*",
+    ... day_of_month="10-15", month_of_year="*"
     """
 
     #
@@ -354,8 +357,8 @@ class CrontabSchedule(models.Model):
 class PeriodicTasks(models.Model):
     """Helper table for tracking updates to periodic tasks.
 
-    This stores a single row with ident=1.  last_update is updated
-    via django signals whenever anything is changed in the PeriodicTask model.
+    This stores a single row with ``ident=1``.  ``last_update`` is updated
+    via django signals whenever anything is changed in the :class:`~.PeriodicTask` model.
     Basically this acts like a DB data audit trigger.
     Doing this so we also track deletions, and not just insert/update.
     """

--- a/django_celery_beat/tzcrontab.py
+++ b/django_celery_beat/tzcrontab.py
@@ -35,8 +35,8 @@ class TzAwareCrontab(schedules.crontab):
     def is_due(self, last_run_at):
         """Calculate when the next run will take place.
 
-        Return tuple of (is_due, next_time_to_check).
-        The last_run_at argument needs to be timezone aware.
+        Return tuple of ``(is_due, next_time_to_check)``.
+        The ``last_run_at`` argument needs to be timezone aware.
 
         """
         # convert last_run_at to the schedule timezone

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,4 +22,17 @@ globals().update(conf.build_config(
         'django_celery_beat.apps',
         r'django_celery_beat.migrations.*',
     ],
+    extlinks={
+      'github_project': (
+        f'https://github.com/%s',
+        'GitHub project',
+      ),
+      'github_pr': (
+        f'https://github.com/celery/django-celery-beat/pull/%s',
+        'GitHub PR #',
+      ),
+    },
+    extra_intersphinx_mapping={
+        'django-celery-results': ('https://django-celery-results.readthedocs.io/en/latest/', None),
+    },
 ))

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -11,7 +11,7 @@ Copyright |copy| 2016, Ask Solem
 
 All rights reserved.  This material may be copied or distributed only
 subject to the terms and conditions set forth in the `Creative Commons
-Attribution-ShareAlike 4.0 International`
+Attribution-ShareAlike 4.0 International
 <http://creativecommons.org/licenses/by-sa/4.0/legalcode>`_ license.
 
 You may share and adapt the material, even for commercial purposes, but

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -31,7 +31,7 @@ Important Warning about Time Zones
     task:
 
        >>> from django_celery_beat.models import PeriodicTask, PeriodicTasks
-       >>> PeriodicTask.objects.all().update(last_run_at=None)
+       >>> PeriodicTask.objects.update(last_run_at=None)
        >>> PeriodicTasks.changed()
 
     Note that this will reset the state as if the periodic tasks have never run

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -17,28 +17,22 @@ Using the Extension
 ===================
 
 Usage and installation instructions for this extension are available
-from the `Celery documentation`_:
-
-http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#using-custom-scheduler-classes
-
-
-.. _`Celery documentation`:
-    http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html#using-custom-scheduler-classes
+from the :ref:`Celery documentation <beat-custom-schedulers>`.
 
 Important Warning about Time Zones
 ==================================
 
 .. warning::
 
-    If you change the Django ``TIME_ZONE`` setting your periodic task schedule
+    If you change the Django :setting:`TIME_ZONE` setting your periodic task schedule
     will still be based on the old timezone.
 
     To fix that you would have to reset the "last run time" for each periodic
-    task::
+    task:
 
-        >>> from django_celery_beat.models import PeriodicTask, PeriodicTasks
-        >>> PeriodicTask.objects.all().update(last_run_at=None)
-        >>> PeriodicTasks.changed()
+       >>> from django_celery_beat.models import PeriodicTask, PeriodicTasks
+       >>> PeriodicTask.objects.all().update(last_run_at=None)
+       >>> PeriodicTasks.changed()
 
     Note that this will reset the state as if the periodic tasks have never run
     before.
@@ -46,36 +40,36 @@ Important Warning about Time Zones
 Models
 ======
 
-- ``django_celery_beat.models.PeriodicTask``
+- :class:`django_celery_beat.models.PeriodicTask`
 
-This model defines a single periodic task to be run.
+  This model defines a single periodic task to be run.
 
-It must be associated with a schedule, which defines how often the task should
-run.
+  It must be associated with a schedule, which defines how often the task should
+  run.
 
-- ``django_celery_beat.models.IntervalSchedule``
+- :class:`django_celery_beat.models.IntervalSchedule`
 
-A schedule that runs at a specific interval (e.g. every 5 seconds).
+  A schedule that runs at a specific interval (e.g. every 5 seconds).
 
-- ``django_celery_beat.models.CrontabSchedule``
+- :class:`django_celery_beat.models.CrontabSchedule`
 
-A schedule with fields like entries in cron:
-``minute hour day-of-week day_of_month month_of_year``.
+  A schedule with fields like entries in cron:
+  ``minute hour day-of-week day_of_month month_of_year``.
 
-- ``django_celery_beat.models.PeriodicTasks``
+- :class:`django_celery_beat.models.PeriodicTasks`
 
-This model is only used as an index to keep track of when the schedule has
-changed.
+  This model is only used as an index to keep track of when the schedule has
+  changed.
 
-Whenever you update a ``PeriodicTask`` a counter in this table is also
+Whenever you update a :class:`~django_celery_beat.models.PeriodicTask`, a counter in this table is also
 incremented, which tells the ``celery beat`` service to reload the schedule
 from the database.
 
 If you update periodic tasks in bulk, you will need to update the counter
-manually::
+manually:
 
-    >>> from django_celery_beat.models import PeriodicTasks
-    >>> PeriodicTasks.changed()
+   >>> from django_celery_beat.models import PeriodicTasks
+   >>> PeriodicTasks.changed()
 
 Example creating interval-based periodic task
 ---------------------------------------------
@@ -83,24 +77,24 @@ Example creating interval-based periodic task
 To create a periodic task executing at an interval you must first
 create the interval object::
 
-    >>> from django_celery_beat.models import PeriodicTask, IntervalSchedule
+   >>> from django_celery_beat.models import PeriodicTask, IntervalSchedule
 
-    # executes every 10 seconds.
-    >>> schedule, created = IntervalSchedule.objects.get_or_create(
-    ...     every=10,
-    ...     period=IntervalSchedule.SECONDS,
-    ... )
+   # executes every 10 seconds.
+   >>> schedule, created = IntervalSchedule.objects.get_or_create(
+   ...     every=10,
+   ...     period=IntervalSchedule.SECONDS,
+   ... )
 
 That's all the fields you need: a period type and the frequency.
 
 You can choose between a specific set of periods:
 
 
-- ``IntervalSchedule.DAYS``
-- ``IntervalSchedule.HOURS``
-- ``IntervalSchedule.MINUTES``
-- ``IntervalSchedule.SECONDS``
-- ``IntervalSchedule.MICROSECONDS``
+- :data:`IntervalSchedule.DAYS <django_celery_beat.models.IntervalSchedule.DAYS>`
+- :data:`IntervalSchedule.HOURS <django_celery_beat.models.IntervalSchedule.HOURS>`
+- :data:`IntervalSchedule.MINUTES <django_celery_beat.models.IntervalSchedule.MINUTES>`
+- :data:`IntervalSchedule.SECONDS <django_celery_beat.models.IntervalSchedule.SECONDS>`
+- :data:`IntervalSchedule.MICROSECONDS <django_celery_beat.models.IntervalSchedule.MICROSECONDS>`
 
 .. note::
 
@@ -108,119 +102,126 @@ You can choose between a specific set of periods:
     then they should all point to the same schedule object.
 
 There's also a "choices tuple" available should you need to present this
-to the user::
+to the user:
 
-    >>> IntervalSchedule.PERIOD_CHOICES
+   >>> IntervalSchedule.PERIOD_CHOICES
 
 
 Now that we have defined the schedule object, we can create the periodic task
-entry::
+entry:
 
-    >>> PeriodicTask.objects.create(
-    ...     interval=schedule,                  # we created this above.
-    ...     name='Importing contacts',          # simply describes this periodic task.
-    ...     task='proj.tasks.import_contacts',  # name of task.
-    ... )
+   >>> PeriodicTask.objects.create(
+   ...     interval=schedule,                  # we created this above.
+   ...     name='Importing contacts',          # simply describes this periodic task.
+   ...     task='proj.tasks.import_contacts',  # name of task.
+   ... )
 
 
 Note that this is a very basic example, you can also specify the arguments
 and keyword arguments used to execute the task, the ``queue`` to send it
-to[*], and set an expiry time.
+to [#f1]_, and set an expiry time.
 
 Here's an example specifying the arguments, note how JSON serialization is
-required::
+required:
 
-    >>> import json
-    >>> from datetime import datetime, timedelta
+   >>> import json
+   >>> from datetime import datetime, timedelta
 
-    >>> PeriodicTask.objects.create(
-    ...     interval=schedule,                  # we created this above.
-    ...     name='Importing contacts',          # simply describes this periodic task.
-    ...     task='proj.tasks.import_contacts',  # name of task.
-    ...     args=json.dumps(['arg1', 'arg2']),
-    ...     kwargs=json.dumps({
-    ...        'be_careful': True,
-    ...     }),
-    ...     expires=datetime.utcnow() + timedelta(seconds=30)
-    ... )
+   >>> PeriodicTask.objects.create(
+   ...     interval=schedule,                  # we created this above.
+   ...     name='Importing contacts',          # simply describes this periodic task.
+   ...     task='proj.tasks.import_contacts',  # name of task.
+   ...     args=json.dumps(['arg1', 'arg2']),
+   ...     kwargs=json.dumps({
+   ...        'be_careful': True,
+   ...     }),
+   ...     expires=datetime.utcnow() + timedelta(seconds=30)
+   ... )
 
 
-.. [*] you can also use low-level AMQP routing using the ``exchange`` and
-       ``routing_key`` fields.
+.. [#f1] you can also use low-level AMQP routing using the ``exchange`` and
+   ``routing_key`` fields.
 
 Example creating crontab-based periodic task
 --------------------------------------------
 
 A crontab schedule has the fields: ``minute``, ``hour``, ``day_of_week``,
-``day_of_month`` and ``month_of_year`, so if you want the equivalent
+``day_of_month`` and ``month_of_year``, so if you want the equivalent
 of a ``30 * * * *`` (execute at 30 minutes past the hour every hour) crontab
-entry you specify::
+entry you specify:
 
-    >>> from django_celery_beat.models import CrontabSchedule, PeriodicTask
-    >>> schedule, _ = CrontabSchedule.objects.get_or_create(
-    ...     minute='30',
-    ...     hour='*',
-    ...     day_of_week='*',
-    ...     day_of_month='*',
-    ...     month_of_year='*',
-    ... )
+   >>> from django_celery_beat.models import CrontabSchedule, PeriodicTask
+   >>> schedule, _ = CrontabSchedule.objects.get_or_create(
+   ...     minute='30',
+   ...     hour='*',
+   ...     day_of_week='*',
+   ...     day_of_month='*',
+   ...     month_of_year='*',
+   ... )
 
 
 Then to create a periodic task using this schedule, use the same approach as
 the interval-based periodic task earlier in this document, but instead
-of ``interval=schedule``, specify ``crontab=schedule``::
+of ``interval=schedule``, specify ``crontab=schedule``:
 
-    >>> PeriodicTask.objects.create(
-    ...     crontab=schedule,
-    ...     name='Importing contacts',
-    ...     task='proj.tasks.import_contacts',
-    ... )
+   >>> PeriodicTask.objects.create(
+   ...     crontab=schedule,
+   ...     name='Importing contacts',
+   ...     task='proj.tasks.import_contacts',
+   ... )
 
 Temporarily disable a periodic task
 -----------------------------------
 
-You can use the ``enabled`` flag to temporarily disable a periodic task::
+You can use the ``enabled`` flag to temporarily disable a periodic task:
 
-    >>> periodic_task.enabled = False
-    >>> periodic_task.save()
+   >>> periodic_task.enabled = False
+   >>> periodic_task.save()
 
 
 Example running periodic tasks
------------------------------------
+------------------------------
 
 The periodic tasks still need 'workers' to execute them.
 So make sure the default **Celery** package is installed.
 (If not installed, please follow the installation instructions
-here: https://github.com/celery/celery)
+here: :github_project:`celery/celery`)
 
 Both the worker and beat services need to be running at the same time.
 
-1. Start a Celery worker service (specify your Django project name)::
+1. Start a Celery worker service (specify your Django project name):
+
+   .. code-block:: sh
+
+      $ celery -A [project-name] worker --loglevel=info
 
 
-    $ celery -A [project-name] worker --loglevel=info
+2. As a separate process, start the beat service (specify the Django scheduler):
+
+   .. code-block:: sh
+
+      $ celery -A [project-name] beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
 
 
-2. As a separate process, start the beat service (specify the Django scheduler)::
+  **OR** you can use the -S (scheduler flag), for more options see ``celery beat --help``):
 
+  .. code-block:: sh
 
-        $ celery -A [project-name] beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+     $ celery -A [project-name] beat -l info -S django
 
+  **OR** you can set the scheduler through Django's settings:
 
-  **OR** you can use the -S (scheduler flag), for more options see ``celery beat --help``)::
+  .. code-block:: sh
 
-            $ celery -A [project-name] beat -l info -S django
-
-  **OR** you can set the scheduler through Django's settings::
-
-            CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+     CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 
 
 Also, as an alternative, you can run the two steps above (worker and beat services)
-with only one command (recommended for **development environment only**)::
+with only one command (recommended for **development environment only**):
 
+.. code-block:: sh
 
-    $ celery -A [project-name] worker --beat --scheduler django --loglevel=info
+   $ celery -A [project-name] worker --beat --scheduler django --loglevel=info
 
 
 3. Now you can add and manage your periodic tasks from the Django Admin interface.
@@ -230,7 +231,8 @@ with only one command (recommended for **development environment only**)::
 Working with django-celery-results
 -----------------------------------
 
-Now you can store PeriodicTask.name to django-celery-results (TaskResult.periodic_task_name).
+Now you can store :attr:`PeriodicTask.name <django_celery_beat.models.PeriodicTask.name>`
+to django-celery-results (``TaskResult.periodic_task_name``).
 
 Suppose we have two periodic tasks, their schedules are different, but the tasks are the same.
 
@@ -241,7 +243,7 @@ Suppose we have two periodic tasks, their schedules are different, but the tasks
 | schedule2 | some.celery.task | (2,) | every 2 hours |
 +-----------+------------------+------+---------------+
 
-Now you can distinguish the source of the task from the results by the `periodic_task_name` field.
+Now you can distinguish the source of the task from the results by the ``periodic_task_name`` field.
 
 +--------+------------------+--------------------+
 |   id   |    task_name     | periodic_task_name |
@@ -252,4 +254,4 @@ Now you can distinguish the source of the task from the results by the `periodic
 | uuid4  | some.celery.task | schedule2          |
 +--------+------------------+--------------------+
 
-(more technical details here: https://github.com/celery/django-celery-beat/pull/477, https://github.com/celery/django-celery-results/pull/261)
+(more technical details here: :github_pr:`477`, :github_pr:`261`)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,3 +2,4 @@ Django>=2.2,<4.1
 https://github.com/celery/sphinx_celery/archive/master.zip
 https://github.com/celery/kombu/zipball/master#egg=kombu
 https://github.com/celery/celery/zipball/master#egg=celery
+-r default.txt


### PR DESCRIPTION
Closes #508.

The last remaining Sphinx warning depends on https://github.com/celery/sphinx_celery/pull/32 (otherwise, no crossrefs to Celery docs are possible). This in turn will produce new Sphinx warning about an unresolved crossref, which is fixed in https://github.com/celery/celery/pull/7357.

Built result: [django-celery-beat-pr docs](https://django-celery-beat-pr.readthedocs.io/en/latest/).