### PR TITLE
Fix typo in settings for celery beat scheduler

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -143,7 +143,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        scheduler = getattr(settings, 'CELERYBEAT_SCHEDULER', None)
+        scheduler = getattr(settings, 'CELERY_BEAT_SCHEDULER', None)
         extra_context['wrong_scheduler'] = not is_database_scheduler(scheduler)
         return super().changelist_view(
             request, extra_context)

--- a/django_celery_beat/templates/admin/djcelery/change_list.html
+++ b/django_celery_beat/templates/admin/djcelery/change_list.html
@@ -11,7 +11,7 @@
     <ul class="messagelist">
       <li class="warning">
       Periodic tasks won't be dispatched unless you set the
-      <code>CELERYBEAT_SCHEDULER</code> setting to
+      <code>CELERY_BEAT_SCHEDULER</code> setting to
       <code>djcelery.schedulers.DatabaseScheduler</code>,
       or specify it using the <code>-S</code> option to celerybeat
       </li>

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -213,7 +213,7 @@ Both the worker and beat services need to be running at the same time.
 
   .. code-block:: sh
 
-     CELERYBEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+     CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 
 
 


### PR DESCRIPTION
When using `CELERYBEAT_SCHEDULER` setting with value `django_celery_beat.schedulers:DatabaseScheduler`, the celery scheduler is still starting with a `celery.beat.PersistentScheduler` scheduler.

Whereas using `CELERY_BEAT_SCHEDULER` setting, still with `django_celery_beat.schedulers:DatabaseScheduler` corrrectly starts the scheduler with a  `django_celery_beat.schedulers.DatabaseScheduler`.