### PR TITLE
Clarify month range

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -292,8 +292,8 @@ class CrontabSchedule(models.Model):
         max_length=64, default='*',
         verbose_name=_('Month(s) Of The Year'),
         help_text=_(
-            'Cron Months Of The Year to Run. Use "*" for "all". '
-            '(Example: "0,6")'),
+            'Cron Months (1-12) Of The Year to Run. Use "*" for "all". '
+            '(Example: "1,12")'),
         validators=[validators.month_of_year_validator],
     )
 


### PR DESCRIPTION
Current example shows 0 as a valid value for month. Valid range is 1-12, as the validator correctly detects.