### PR TITLE
Start time heap block fix

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -84,7 +84,11 @@ class ModelEntry(ScheduleEntry):
         self.model = model
 
         if not model.last_run_at:
-            model.last_run_at = self._default_now() - datetime.timedelta(days=365*30)
+            model.last_run_at = self._default_now()
+            # if last_run_at is not set and model.start_time last_run_at should be in way past.
+            # This will trigger the job to run at start_time and avoid the heap block.
+            if self.model.start_time:
+                model.last_run_at = model.last_run_at - datetime.timedelta(days=365*30)
 
         self.last_run_at = model.last_run_at
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -84,7 +84,7 @@ class ModelEntry(ScheduleEntry):
         self.model = model
 
         if not model.last_run_at:
-            model.last_run_at = self._default_now()
+            model.last_run_at = self._default_now() - datetime.timedelta(days=365*30)
 
         self.last_run_at = model.last_run_at
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -91,7 +91,7 @@ class ModelEntry(ScheduleEntry):
             # and avoid the heap block.
             if self.model.start_time:
                 model.last_run_at = model.last_run_at \
-                                    - datetime.timedelta(days=365 * 30)
+                    - datetime.timedelta(days=365 * 30)
 
         self.last_run_at = model.last_run_at
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -87,9 +87,11 @@ class ModelEntry(ScheduleEntry):
             model.last_run_at = self._default_now()
             # if last_run_at is not set and
             # model.start_time last_run_at should be in way past.
-            # This will trigger the job to run at start_time and avoid the heap block.
+            # This will trigger the job to run at start_time
+            # and avoid the heap block.
             if self.model.start_time:
-                model.last_run_at = model.last_run_at - datetime.timedelta(days=365 * 30)
+                model.last_run_at = model.last_run_at \
+                                    - datetime.timedelta(days=365 * 30)
 
         self.last_run_at = model.last_run_at
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -85,10 +85,11 @@ class ModelEntry(ScheduleEntry):
 
         if not model.last_run_at:
             model.last_run_at = self._default_now()
-            # if last_run_at is not set and model.start_time last_run_at should be in way past.
+            # if last_run_at is not set and
+            # model.start_time last_run_at should be in way past.
             # This will trigger the job to run at start_time and avoid the heap block.
             if self.model.start_time:
-                model.last_run_at = model.last_run_at - datetime.timedelta(days=365*30)
+                model.last_run_at = model.last_run_at - datetime.timedelta(days=365 * 30)
 
         self.last_run_at = model.last_run_at
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -600,6 +600,7 @@ class test_DatabaseScheduler(SchedulerCase):
         assert len(tried) == 1 and tried == {e1.name}
 
     def test_starttime_trigger(self, monkeypatch):
+        # Ensure there is no heap block in case of new task with start_time
         PeriodicTask.objects.all().delete()
         s = self.Scheduler(app=self.app)
         assert not s._heap

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -608,7 +608,10 @@ class test_DatabaseScheduler(SchedulerCase):
         m1.save()
         s.tick()
         assert len(s._heap) == 2
-        m2 = self.create_model_interval(schedule(timedelta(days=1)), start_time=make_aware(datetime.now() + timedelta(seconds=2)))
+        m2 = self.create_model_interval(
+            schedule(timedelta(days=1)),
+            start_time=make_aware(
+                datetime.now() + timedelta(seconds=2)))
         m2.save()
         s.tick()
         assert s._heap[0][2].name == m2.name

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -599,6 +599,25 @@ class test_DatabaseScheduler(SchedulerCase):
                     s.sync()
         assert len(tried) == 1 and tried == {e1.name}
 
+    def test_starttime_trigger(self, monkeypatch):
+        PeriodicTask.objects.all().delete()
+        s = self.Scheduler(app=self.app)
+        assert not s._heap
+        m1 = self.create_model_interval(schedule(timedelta(seconds=3)))
+        m1.save()
+        s.tick()
+        assert len(s._heap) == 2
+        m2 = self.create_model_interval(schedule(timedelta(days=1)), start_time=make_aware(datetime.now() + timedelta(seconds=2)))
+        m2.save()
+        s.tick()
+        assert s._heap[0][2].name == m2.name
+        assert len(s._heap) == 3
+        assert s._heap[0]
+        time.sleep(2)
+        s.tick()
+        assert s._heap[0]
+        assert s._heap[0][2].name == m1.name
+
 
 @pytest.mark.django_db()
 class test_models(SchedulerCase):


### PR DESCRIPTION
This is the fix for full heap block in case a task gets added with start_time.
More issue described at below issue link.

https://github.com/celery/django-celery-beat/issues/274

This has caused production issue many times.

Including test case for the same, which will fail, if you revert the changes in core logic.