### PR TITLE
Fix Issue #388: Celery Beat scheduled tasks may be executed repeatedly

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -302,7 +302,7 @@ class DatabaseScheduler(Scheduler):
                 try:
                     self._schedule[name].save()
                     _tried.add(name)
-                except (KeyError, ObjectDoesNotExist):
+                except (KeyError, TypeError, ObjectDoesNotExist):
                     _failed.add(name)
         except DatabaseError as exc:
             logger.exception('Database error while sync: %r', exc)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -300,7 +300,7 @@ class DatabaseScheduler(Scheduler):
             while self._dirty:
                 name = self._dirty.pop()
                 try:
-                    self.schedule[name].save()
+                    self._schedule[name].save()
                     _tried.add(name)
                 except (KeyError, ObjectDoesNotExist):
                     _failed.add(name)


### PR DESCRIPTION
## Describe

Fix the problem that Celery Beat scheduled tasks may be executed repeatedly

## Problem

### Describe

If `self.schedule` is called, it may cause the data in the database to be retrieved before the `self.save()` method, instead of the temporarily set `last_run_at data`

If `self.schedule` is called here
Then it may cause the `last_run_at` of `self.schedule[name]` calling save to be the old data retrieved from the database
Instead of `last_run_at` temporarily set after task execution (set in `__next__()` method)
After the `max_interval` interval, the next task detection cycle will still execute the task again

### Demo

Task information:
   >beat config: max_interval = 60s
  
   >Task name: cap
   >Task execution cycle: Execute every 3 minutes
   >Task last execution time: 18:00

The first execution of the task: 18:03 (set `last_run_at` = 18:03 when executing, and it is in memory at this time)
                    
   >After the task execution is completed,
   >It is detected that sync is required, and `self.schedule` is called in `sync`,
   >If `schedule_changed()` is found to be `True` in `self.schedule`, `all_as_schedule()` needs to be called
   >At this point, the `last_run_at` of `self.schedule[name]` called in `sync` is 18:00
   >At this time, `self.save()` is performed in `self.sync()`

beat: Waking up 60s...
                    
The second execution of the task: 18:04 (because the `last_run_at` obtained is 18:00, `entry.is_due()` == `True`)

## Test
There are currently no test cases.

## Effect
After modifying the code, the problem of repeated execution no longer appeared in our project [JumpServer](https://github.com/jumpserver/jumpserver/pull/10936/files).