### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,12 +298,12 @@ Using the development version
 With pip
 ~~~~~~~~
 
-You can install the latest snapshot of django-celery-beat using the following
+You can install the latest main version of django-celery-beat using the following
 pip command:
 
 .. code-block:: bash
 
-        $ pip install https://github.com/celery/django-celery-beat/zipball/master#egg=django-celery-beat
+        $ pip install git+https://github.com/celery/django-celery-beat#egg=django-celery-beat
 
 
 Developing django-celery-beat


### PR DESCRIPTION
- Use `git` instead of `zipfile` for installing from Github

Recommend using git instead of zipball because of Pipenv. When installing with Pipenv, once the repo is updated, the hash for the file changes and Pipenv refuses to update. It may be a reasonable default for Pipenv, but all problems are avoided if it is used git instead (see https://github.com/math-a3k/tradero/commit/514edb0e0ce44a117d639ec96da5724dcf7392e5)