### PR TITLE
Replace case.patching fixture with mockeypatch + MagicMock

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-case>=1.3.1
 pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<8.0
 pytest-timeout

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 # we have to import the pytest plugin fixtures here,
 # in case user did not do the `python setup.py develop` yet,
@@ -40,3 +42,11 @@ def test_cases_shortcuts(request, app, patching):
     yield
     if request.instance:
         request.instance.app = None
+
+
+@pytest.fixture
+def patching(monkeypatch):
+    def _patching(attr):
+        monkeypatch.setattr(attr, MagicMock())
+
+    return _patching


### PR DESCRIPTION
The amount of failing test-cases put my on the wrong foot since patching was used in an autouse fixture.

This PR has a minimal implementation of the `patching` fixture of `case` and drops `case` as dependency. as required in #691 

