### PR TITLE
Testing Django v5.0 on pypy-3.10-v7.3.14 passes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10-v7.3.14']
 
     services:
       rabbitmq:

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
     py310-django{32,41,42,50}
     py311-django{41,42,50}
     py312-django{41,42,50}
-    pypy3-django{32,41,42}
+    pypy3-django{32,41,42,50}
     flake8
     apicheck
     linkcheck


### PR DESCRIPTION
Identical to #699 but ___adds a single tox test that fails___: Django v5.0 on pypy-3.10-v7.3.14.
* #699
* https://github.com/celery/django-celery-beat/pull/699#issuecomment-1863399975

---
`tox_gh_actions` prefers the hyphen in `pypy-3.10` (not `pypy3.10`)
https://github.com/ymyzk/tox-gh-actions/blob/master/src/tox_gh_actions/plugin.py#L174

Fixes #708
* #708