### PR TITLE
Fix Django 5.0 with PyPy 3.10

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Darjus Loktevic <darjus@amazon.com>
 David Fischer <david.fischer.ch@gmail.com>
 David Ziegler <david.ziegler@gmail.com>
 Diego Andres Sanabria Martin <diegueus9@gmail.com>
+Dima Doroshev <dima@doroshev.com>
 Dmitriy Krasilnikov <krasilnikov.d.o@gmail.com>
 Donald Stufft <donald.stufft@gmail.com>
 Eldon Stegall

--- a/Changelog
+++ b/Changelog
@@ -6,7 +6,8 @@
 
 Next
 ====
-- Formally support Python 3.12.
+- Formally support Python 3.12 and PyPy 3.10.
+- Formally support Django 5.0.
 
 .. _version-2.5.0:
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -27,21 +27,21 @@ MINUTES = 'minutes'
 SECONDS = 'seconds'
 MICROSECONDS = 'microseconds'
 
-PERIOD_CHOICES = (
+PERIOD_CHOICES = [
     (DAYS, _('Days')),
     (HOURS, _('Hours')),
     (MINUTES, _('Minutes')),
     (SECONDS, _('Seconds')),
     (MICROSECONDS, _('Microseconds')),
-)
+]
 
-SINGULAR_PERIODS = (
+SINGULAR_PERIODS = [
     (DAYS, _('Day')),
     (HOURS, _('Hour')),
     (MINUTES, _('Minute')),
     (SECONDS, _('Second')),
     (MICROSECONDS, _('Microsecond')),
-)
+]
 
 SOLAR_SCHEDULES = [
     ("dawn_astronomical", _("Astronomical dawn")),

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
     py310-django{32,41,42,50}
     py311-django{41,42,50}
     py312-django{41,42,50}
-    pypy3-django{32,41,42}
+    pypy3-django{32,41,42,50}
     flake8
     apicheck
     linkcheck


### PR DESCRIPTION
This PR fixes the problem of generating redundant migrations in PyPy 3.10/Django 5.0 environment.

In Django 5.0 they changed the way of normalizing choices, using [`match`](https://github.com/django/django/blob/45f778eded9dff59cfdd4dce8720daf87a08cfac/django/utils/choices.py#L76-L105).

CPython works fine with `case Iterable()`, so the choices always go through [this list comprehension](https://github.com/django/django/blob/45f778eded9dff59cfdd4dce8720daf87a08cfac/django/utils/choices.py#L109), being converted from tuples to lists every time.

PyPy 3.10-7.3.13 has a bug, it can't match `case Iterable()`, but works with `case Iterable` instead (which is wrong). So the test was failing, because the rendered schema contained `choices=[..., ...]`, while schema generated from the models containted `choices=(..., ...)`, which caused a redundant auto generated migration.

PyPy [fixed](https://foss.heptapod.net/pypy/pypy/-/commit/461b1615847a16570ec820b6562e188f80e8d73c) it in 7.3.14 though.

[Changelog](https://doc.pypy.org/en/latest/release-v7.3.14.html#id3):
> ### Python 3.10
>  <...>
>  - Pattern matching classes now use the full `isinstance` machinery, calling `__instancecheck__` too. ([#4036](https://foss.heptapod.net/pypy/pypy/-/issues/4036))

(The issue itself is unavailable, probably because they're moving to GitHub.)

So this small change of converting choices to lists fixes the problem.

Related issues and PRs:
- #698 
- #699 
- #705