### PR TITLE
Prepare for release v2.6.0 to support Py3.12 and Dj5.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,7 +6,26 @@
 
 Next
 ====
-- Formally support Python 3.12.
+
+
+2.6.0
+=====
+release-date: !!! FIX_ME !!!
+:release-by: !!! FIX_ME !!!
+- Formally support Python 3.12. (#690)
+- Avoid crash when can not get human readable description (#648)
+- Update codeql-analysis.yml (#653)
+- Celery Beat scheduled tasks may be executed repeatedly (#660)
+- Drop Django 4.0 from CI to avoid security issues (#662)
+- Change assert self.app.timezone.zone to assert self.app.timezone.key (#664)
+- README.rst: Use git instead of zipfile for installing from Github (#670)
+- Update supported Python & Django version in setup.py (#672)
+- Update runtime.txt to include Django 5.0 (#681)
+- README.rst: Crontab effect description (#689)
+- Replace case.patching fixture with mockeypatch + MagicMock (#692)
+- Upgrade GitHub Actions and PyPy 3.10 and Django 5.0 (#699, #705)
+- Django v5.0: django.utils.timezone.utc alias --> datetime.timezone.utc (#703)
+
 
 .. _version-2.5.0:
 

--- a/Changelog
+++ b/Changelog
@@ -10,7 +10,7 @@ Next
 
 2.6.0
 =====
-release-date: !!! FIX_ME !!!
+:release-date: !!! FIX_ME !!!
 :release-by: !!! FIX_ME !!!
 - Formally support Python 3.12. (#690)
 - Avoid crash when can not get human readable description (#648)

--- a/Changelog
+++ b/Changelog
@@ -12,6 +12,7 @@ Next
 =====
 :release-date: !!! FIX_ME !!!
 :release-by: !!! FIX_ME !!!
+
 - Formally support Python 3.12. (#690)
 - Avoid crash when can not get human readable description (#648)
 - Update codeql-analysis.yml (#653)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ classes = """
     Framework :: Django :: 3.2
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
     Operating System :: OS Independent
     Topic :: Communications
     Topic :: System :: Distributed Computing


### PR DESCRIPTION
Fixes: #698
Fixes: #711

A release to PyPI is required to add support for Python v3.12 and Django v5.0.   See: https://github.com/celery/django-celery-beat/issues/698#issuecomment-1845437625