### PR TITLE
GitHub Actions: Do not hardcode an out-of-date version of PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10-v7.3.14']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
 
     services:
       rabbitmq:


### PR DESCRIPTION
PyPy v7.3.15 is now available:
* https://doc.pypy.org/en/latest/index-of-release-notes.html
* Next step after #705
```diff
    strategy:
      fail-fast: false
      matrix:
-       python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10-v7.3.14']
+       python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
```
# Note: The Sphinx failures discussed below were fixed in:
* celery/sphinx_celery#66