### PR TITLE
Remove code for unsupported django.VERSION < (3, 2)

### DIFF
--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -5,8 +5,6 @@
 import re
 from collections import namedtuple
 
-import django
-
 __version__ = '2.5.0'
 __author__ = 'Asif Saif Uddin, Ask Solem'
 __contact__ = 'auvipy@gmail.com, ask@celeryproject.org'
@@ -29,6 +27,3 @@ del _temp
 del re
 
 __all__ = []
-
-if django.VERSION < (3, 2):
-    default_app_config = 'django_celery_beat.apps.BeatConfig'


### PR DESCRIPTION
~% `django-upgrade --target version=5.0 **/*.py`~

~https://github.com/adamchainz/django-upgrade/blob/main/README.rst~

--
```diff
- import django

- if django.VERSION < (3, 2):
-     default_app_config = 'django_celery_beat.apps.BeatConfig'
```