### PR TITLE
added sphinxcontrib-django to extensions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ globals().update(conf.build_config(
             None
         ),
     },
+    extensions=['sphinxcontrib_django']
 ))
 
 intersphinx_mapping = globals().get('intersphinx_mapping', {})

--- a/docs/reference/django-celery-beat.models.rst
+++ b/docs/reference/django-celery-beat.models.rst
@@ -8,4 +8,3 @@
 
 .. automodule:: django_celery_beat.models
     :members:
-    :undoc-members:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,5 @@
 Django>=2.2,<5.0
+sphinxcontrib-django
 https://github.com/celery/sphinx_celery/archive/master.zip
 https://github.com/celery/kombu/zipball/main#egg=kombu
 https://github.com/celery/celery/zipball/main#egg=celery


### PR DESCRIPTION
Closes #735. To test this, first install the new dependency with `pip install requirements/docs.txt` and then build the docs normally.