### PR TITLE
fix display of long name day of week

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -326,7 +326,7 @@ class CrontabSchedule(models.Model):
                 day_of_month=self.day_of_month,
                 month_of_year=self.month_of_year,
             )
-            day_of_week = cronexp(",".join(map(str, c.day_of_week)))
+            day_of_week = cronexp(",".join(str(day) for day in c.day_of_week))
         except ValueError:
             day_of_week = cronexp(self.day_of_week)
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 
 import timezone_field
 from celery import current_app, schedules
-from celery.schedules import crontab
 from cron_descriptor import (FormatException, MissingFieldException,
                              WrongArgumentException, get_description)
 from django.conf import settings

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -226,21 +226,27 @@ class HumanReadableTestCase(TestCase):
         cron = CrontabSchedule.objects.create(
             hour="2",
             minute="0",
-            day_of_week="monxxx",
+            day_of_week="xxx",
         )
         self.assertEqual(
-            cron.human_readable, "0 2 * * monxxx UTC"
+            cron.human_readable, "0 2 * * xxx UTC"
         )
 
     def test_long_name(self):
         """Long day name display."""
-        # TODO: this should eventually work, but probably needs conversion
-        # before passing data to cron_description
-        cron = CrontabSchedule.objects.create(
-            hour="2",
-            minute="0",
-            day_of_week="monday",
-        )
-        self.assertEqual(
-            cron.human_readable, "0 2 * * monday UTC"
-        )
+        for day_day_of_week, expected in (
+            ("1", "Monday"),
+            ("mon", "Monday"),
+            ("Monday,tue", "Monday and Tuesday"),
+            ("sat-sun/2", "Saturday"),
+            ("mon-wed", "Monday, Tuesday, and Wednesday"),
+        ):
+            cron = CrontabSchedule.objects.create(
+                hour="2",
+                minute="0",
+                day_of_week=day_day_of_week,
+            )
+
+            self.assertEqual(
+                cron.human_readable, f"At 02:00 AM, only on {expected} UTC"
+            )


### PR DESCRIPTION
Fix display of long name for day of week at Admin panel.

issue: https://github.com/celery/django-celery-beat/issues/647
previous workaround: https://github.com/celery/django-celery-beat/commit/2798e36fd884b1cf2324acfb09a587009b6954ba