### PR TITLE
ci: add a github workflow to build and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build & Publish to PyPI
+
+on:
+  workflow_dispatch:
+  # Ensure the build works on main
+  push:
+    branches: [main]
+    tags: ['*']
+  # Ensure the build works on each pull request
+  pull_request:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-22.04
+
+    needs: [build]
+
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-celery-beat
+    
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Upload them to GitHub Release
+    runs-on: ubuntu-22.04
+
+    needs: [publish-to-pypi]
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --notes ""
+      
+      - name: Upload artifact to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'


### PR DESCRIPTION
Hi :wave: 

I submit a PR to build & publish the wheel in CI. 

I don't know why, but no wheel is released on PyPI for the 2.6.0 version of `django-celery-beat`. So accordingly to the pypa example: [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), I add a workflow that automatically:
- build the package on `pull_request`, the `main` branch and tags, 
- publish the wheel and the source tarball to PyPI, on pushed tag,
> but required some configuration on the PyPI repo, to  configure the workflow as a trusted publisher (see [configuring-trusted-publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing)).
- create a Github Release, and upload the artifacts.