### PR TITLE
Start testing on Django v5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-        django-version: ["3.2", "4.2", "5.0", "5.1a1"]
+        django-version: ["3.2", "4.2", "5.0", "5.1"]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
         exclude:
           - django-version: "3.2"
@@ -23,9 +23,9 @@ jobs:
             python-version: "3.8"
           - django-version: "5.0"
             python-version: "3.9"
-          - django-version: "5.1a1"
+          - django-version: "5.1"
             python-version: "3.8"
-          - django-version: "5.1a1"
+          - django-version: "5.1"
             python-version: "3.9"
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-        django-version: ["3.2", "4.2", "5.0"]
+        django-version: ["3.2", "4.2", "5.0", "5.1a1"]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
         exclude:
           - django-version: "3.2"
@@ -22,6 +22,10 @@ jobs:
           - django-version: "5.0"
             python-version: "3.8"
           - django-version: "5.0"
+            python-version: "3.9"
+          - django-version: "5.1a1"
+            python-version: "3.8"
+          - django-version: "5.1a1"
             python-version: "3.9"
 
     services:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ classes = """
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
+    Framework :: Django :: 5.1
     Operating System :: OS Independent
     Topic :: Communications
     Topic :: System :: Distributed Computing

--- a/tox.ini
+++ b/tox.ini
@@ -15,15 +15,16 @@ DJANGO =
     4.1: django41
     4.2: django42
     5.0: django50
+    5.1: django51
 
 [tox]
 envlist =
     py38-django{32,42}
     py39-django{32,42}
-    py310-django{32,42,50}
-    py311-django{42,50}
-    py312-django{42,50}
-    pypy3-django{32,42,50}
+    py310-django{32,42,50,51}
+    py311-django{42,50,51}
+    py312-django{42,50,51}
+    pypy3-django{32,42,50,51}
     flake8
     apicheck
     linkcheck
@@ -42,6 +43,7 @@ deps=
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0
+	django51: Django ~= 5.1
 
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps=
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0
-	django51: Django ~= 5.1a1
+	django51: Django ~= 5.1b1
 
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps=
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0
-	django51: Django ~= 5.1
+	django51: Django ~= 5.1a1
 
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
Test the **pre-release** version of Django v5.1 scheduled to be released in August 2024.
* https://docs.djangoproject.com/en/dev/releases/5.1

---
Why does upgrading Django v5.0 --> v5.1b1 ___downgrade___ these?
* This is a repeat on Django v5.1 of https://github.com/celery/django-celery-beat/issues/680#issuecomment-1846762450
```
django-celery-beat: 2.6.0 --> 2.1.0
django-timezone-field: 6.1.0 --> 4.2.3

% diff django-celery-beat-on-dj50/requirements.txt  \
       django-celery-beat-on-dj51b1/requirements.txt

9,12c9,11
< cron-descriptor==1.4.3
< Django==5.0.6
< django-celery-beat==2.6.0
< django-timezone-field==6.1.0
---
> Django==5.1b1
> django-celery-beat==2.1.0
> django-timezone-field==4.2.3
16a16
> pytz==2024.1
```
---
```
mkdir django-celery-beat-on-dj50 \
 && cd django-celery-beat-on-dj50 \
 && python3.12 -m venv venv \
 && source venv/bin/activate \
 && pip install --upgrade pip \
 && pip install Django==5.0.6 django-celery-beat \
 && pip freeze > requirements.txt \
 && cd .. \
 && mkdir django-celery-beat-on-dj51b1 \
 && cd django-celery-beat-on-dj51b1 \
 && python3.12 -m venv venv \
 && source venv/bin/activate \
 && pip install --upgrade pip \
 && pip install Django==5.1b1 django-celery-beat \
 && pip freeze > requirements.txt \
 && cd .. \
 && diff django-celery-beat-on-dj50/requirements.txt  \
         django-celery-beat-on-dj51b1/requirements.txt \
 && rm -fr django-celery-beat-on-dj5*
```