### PR TITLE
Fix Tasks list in admin

### DIFF
--- a/django_celery_beat/apps.py
+++ b/django_celery_beat/apps.py
@@ -14,7 +14,8 @@ class BeatConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
-        from .signals import signals_connect
         from celery import current_app
+
+        from .signals import signals_connect
         signals_connect()
         current_app.autodiscover_tasks(force=True)

--- a/django_celery_beat/apps.py
+++ b/django_celery_beat/apps.py
@@ -15,4 +15,6 @@ class BeatConfig(AppConfig):
 
     def ready(self):
         from .signals import signals_connect
+        from celery import current_app
         signals_connect()
+        current_app.autodiscover_tasks(force=True)


### PR DESCRIPTION
The list of available tasks in admin (`TaskSelectWidget`) is based on currently loaded tasks. But celery `autodiscover_tasks` is lazy: "the actual auto-discovery won't happen until an application imports the default modules", ie. in worker.

This fix ensures that all tasks will be listed in `TaskSelectWidget`.