### PR TITLE
fix/clarify update_changed after TZ change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,7 @@ Important Warning about Time Zones
 
         >>> from django_celery_beat.models import PeriodicTask, PeriodicTasks
         >>> PeriodicTask.objects.all().update(last_run_at=None)
-        >>> for task in PeriodicTask.objects.all():
-        >>>     PeriodicTasks.changed(task)
+        >>> PeriodicTasks.update_changed()
 
 
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -32,7 +32,7 @@ Important Warning about Time Zones
 
        >>> from django_celery_beat.models import PeriodicTask, PeriodicTasks
        >>> PeriodicTask.objects.update(last_run_at=None)
-       >>> PeriodicTasks.changed()
+       >>> PeriodicTasks.update_changed()
 
     Note that this will reset the state as if the periodic tasks have never run
     before.


### PR DESCRIPTION
I've stumbled over this on the docs website [here](https://django-celery-beat.readthedocs.io/en/latest/#important-warning-about-time-zones).

The code example there will raise `TypeError: PeriodicTasks.changed() missing 1 required positional argument: 'instance'`, as that expects the `PeriodicTask` instance as an argument, probably in a for loop as in the Readme [here](https://github.com/celery/django-celery-beat?tab=readme-ov-file#important-warning-about-time-zones).

I've set it to `update_changed`, I assume that will do the same as looping through the PeriodicTask instances and calling `changed` on each?