### PR TITLE
tox.ini: Upgrade to Django v5.1 release candidate 1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps=
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0
-	django51: Django ~= 5.1b1
+	django51: Django ~= 5.1rc1
 
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
* #761 

Test the **release candidate** version of Django v5.1 scheduled to be released in August 2024.
* https://pypi.org/project/Django/#history
* https://docs.djangoproject.com/en/dev/releases/5.1
