### PR TITLE
pre-commit autoupdate 2024-08-21 to fix PT001 and PT023

### DIFF
--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -22,7 +22,7 @@ def setup_default_app_trap():
     set_default_app(Trap())
 
 
-@pytest.fixture()
+@pytest.fixture
 def app(celery_app):
     return celery_app
 
@@ -44,7 +44,7 @@ def test_cases_shortcuts(request, app, patching):
         request.instance.app = None
 
 
-@pytest.fixture()
+@pytest.fixture
 def patching(monkeypatch):
     def _patching(attr):
         monkeypatch.setattr(attr, MagicMock())

--- a/t/unit/test_admin.py
+++ b/t/unit/test_admin.py
@@ -11,7 +11,7 @@ from django_celery_beat.models import (DAYS, ClockedSchedule, CrontabSchedule,
                                        SolarSchedule)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class ActionsTests(TestCase):
 
     @classmethod
@@ -76,7 +76,7 @@ class ActionsTests(TestCase):
         self.assertTrue(e3)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class ValidateUniqueTests(TestCase):
 
     def test_validate_unique_raises_if_schedule_not_set(self):
@@ -115,7 +115,7 @@ class ValidateUniqueTests(TestCase):
         PeriodicTask(clocked=ClockedSchedule(), one_off=True).validate_unique()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class DisableTasksTest(TestCase):
 
     @classmethod

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -160,7 +160,7 @@ class ClockedScheduleTestCase(TestCase, TestDuplicatesMixin):
         assert str(schedule.clocked_time) == str(schedule)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class OneToOneRelTestCase(TestCase):
     """
     Make sure that when OneToOne relation Model changed,

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -58,7 +58,7 @@ class TrackingScheduler(schedulers.DatabaseScheduler):
         schedulers.DatabaseScheduler.sync(self)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class SchedulerCase:
 
     def create_model_interval(self, schedule, **kwargs):
@@ -113,7 +113,7 @@ class SchedulerCase:
         return CrontabSchedule.objects.create()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_ModelEntry(SchedulerCase):
     Entry = EntryTrackSave
 
@@ -292,11 +292,11 @@ class test_ModelEntry(SchedulerCase):
         assert delay == NEVER_CHECK_TIMEOUT
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_DatabaseSchedulerFromAppConf(SchedulerCase):
     Scheduler = TrackingScheduler
 
-    @pytest.mark.django_db()
+    @pytest.mark.django_db
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
@@ -348,11 +348,11 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         assert self.m1.crontab is None
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_DatabaseScheduler(SchedulerCase):
     Scheduler = TrackingScheduler
 
-    @pytest.mark.django_db()
+    @pytest.mark.django_db
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app
@@ -645,7 +645,7 @@ class test_DatabaseScheduler(SchedulerCase):
         assert s._heap[0][2].name == m1.name
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_models(SchedulerCase):
 
     def test_IntervalSchedule_unicode(self):
@@ -802,7 +802,7 @@ class test_models(SchedulerCase):
         assert (nextcheck2 == NEVER_CHECK_TIMEOUT) and (isdue2 is True)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_model_PeriodicTasks(SchedulerCase):
 
     def test_track_changes(self):
@@ -818,9 +818,9 @@ class test_model_PeriodicTasks(SchedulerCase):
         assert y > x
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 class test_modeladmin_PeriodicTaskAdmin(SchedulerCase):
-    @pytest.mark.django_db()
+    @pytest.mark.django_db
     @pytest.fixture(autouse=True)
     def setup_scheduler(self, app):
         self.app = app


### PR DESCRIPTION
* https://docs.astral.sh/ruff/rules/pytest-fixture-incorrect-parentheses-style/
* https://docs.astral.sh/ruff/rules/pytest-incorrect-mark-parentheses-style/

# pytest-incorrect-mark-parentheses-style (PT023)

Derived from the **flake8-pytest-style** linter.

Fix is always available.

## What it does
Checks for argument-free `@pytest.mark.<marker>()` decorators with or
without parentheses, depending on the [`lint.flake8-pytest-style.mark-parentheses`]
setting.

The rule defaults to removing unnecessary parentheses,
to match the documentation of the official pytest projects.

## Why is this bad?
If a `@pytest.mark.<marker>()` doesn't take any arguments, the parentheses are
optional.

Either removing those unnecessary parentheses _or_ requiring them for all
fixtures is fine, but it's best to be consistent.

## Example

```python
import pytest


@pytest.mark.foo
def test_something(): ...
```

Use instead:

```python
import pytest


@pytest.mark.foo()
def test_something(): ...
```

## Options
- `lint.flake8-pytest-style.mark-parentheses`

## References
- [`pytest` documentation: Marks](https://docs.pytest.org/en/latest/reference/reference.html#marks)
