### PR TITLE
Bump version: 2.6.0 → 2.7.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.0
+current_version = 2.7.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 2.6.0
+:Version: 2.7.0
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat

--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -5,7 +5,7 @@
 import re
 from collections import namedtuple
 
-__version__ = '2.6.0'
+__version__ = '2.7.0'
 __author__ = 'Asif Saif Uddin, Ask Solem'
 __contact__ = 'auvipy@gmail.com, ask@celeryproject.org'
 __homepage__ = 'https://github.com/celery/django-celery-beat'

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 2.6.0
+:Version: 2.7.0
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat


### PR DESCRIPTION
% `pipx install --include-deps bump2version`
% `bump2version minor`
% `git diff main`
* Ensure that `bump2version` updates the version in files:
    * `.bumpversion.cfg`, `README.rst`, `django_celery_beat/__init__.py`, and `docs/includes/introduction.txt`