### PR TITLE
Issue 796: remove days of the week from human readable description when the whole week is specified

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -325,7 +325,10 @@ class CrontabSchedule(models.Model):
                 day_of_month=self.day_of_month,
                 month_of_year=self.month_of_year,
             )
-            day_of_week = cronexp(",".join(str(day) for day in c.day_of_week))
+            if c.day_of_week and set(c.day_of_week) == set(range(7)):
+                day_of_week = "*"
+            else:
+                day_of_week = cronexp(",".join(map(str, c.day_of_week)))
         except ValueError:
             day_of_week = cronexp(self.day_of_week)
 

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -234,11 +234,16 @@ class HumanReadableTestCase(TestCase):
     def test_long_name(self):
         """Long day name display."""
         for day_day_of_week, expected in (
-            ("1", "Monday"),
-            ("mon", "Monday"),
-            ("Monday,tue", "Monday and Tuesday"),
-            ("sat-sun/2", "Saturday"),
-            ("mon-wed", "Monday, Tuesday, and Wednesday"),
+            ("1", ", only on Monday"),
+            ("mon", ", only on Monday"),
+            ("Monday,tue", ", only on Monday and Tuesday"),
+            ("sat-sun/2", ", only on Saturday"),
+            ("mon-wed", ", only on Monday, Tuesday, and Wednesday"),
+            ("*", ""),
+            ("0-6", ""),
+            ("2-1", ""),
+            ("mon-sun", ""),
+            ("tue-mon", ""),
         ):
             cron = CrontabSchedule.objects.create(
                 hour="2",
@@ -247,5 +252,7 @@ class HumanReadableTestCase(TestCase):
             )
 
             self.assertEqual(
-                cron.human_readable, f"At 02:00 AM, only on {expected} UTC"
+                cron.human_readable,
+                f"At 02:00 AM{expected} UTC",
+                day_day_of_week,
             )


### PR DESCRIPTION
Example from the issue #796 
Before (2.6.0): "At 01:00 AM UTC"
After (2.7.0): "At 01:00 AM, only on Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, and Saturday UTC"

This PR return the previous behaviour in case all days of the week are specified:
`0 2 * * *` -> `"At 02:00 AM UTC"`