### PR TITLE
Fix for missing periodic task name in results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,20 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["3.2", "4.2", "5.0", "5.1"]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         exclude:
           - django-version: "3.2"
             python-version: "3.11"
           - django-version: "3.2"
             python-version: "3.12"
-          - django-version: "5.0"
-            python-version: "3.8"
+          - django-version: "3.2"
+            python-version: "3.13"
+          - django-version: "4.2"
+            python-version: "3.13"
           - django-version: "5.0"
             python-version: "3.9"
-          - django-version: "5.1"
-            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.13"
           - django-version: "5.1"
             python-version: "3.9"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         DJANGO: ${{ matrix.django-version }}
     - name: Upload coverage reports to Codecov
       if: ${{ matrix.python-version != 'pypy-3.10' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true # optional (default = false)
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,17 +38,17 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.3.0
+    rev: 2.4.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.20.2
+    rev: v0.21
     hooks:
       - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,13 +38,13 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.4.3
+    rev: v2.5.0
     hooks:
       - id: pyproject-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.7.3
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff
@@ -49,6 +49,6 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.22
+    rev: v0.23
     hooks:
       - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.8.0
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: "migrations"
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.18.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -32,7 +32,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.21.0
+    rev: 1.22.1
     hooks:
       - id: django-upgrade
         args: [--target-version, "3.2"]
@@ -44,7 +44,7 @@ repos:
       - id: ruff
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.2.4
+    rev: 2.3.0
     hooks:
       - id: pyproject-fmt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: "migrations"
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -38,17 +38,17 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.4.3
+    rev: v2.4.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.21
+    rev: v0.22
     hooks:
       - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
       - id: isort
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.22.1
+    rev: 1.22.2
     hooks:
       - id: django-upgrade
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.1
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.8.2
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.7.4
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -248,13 +248,19 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             )
             return
 
-
         task_ids = [
-            task.apply_async(args=args, kwargs=kwargs, queue=queue,
-                             headers={'periodic_task_name':periodic_task_name})
+            task.apply_async(
+                args=args,
+                kwargs=kwargs,
+                queue=queue,
+                headers={'periodic_task_name': periodic_task_name}
+            )
             if queue and len(queue)
-            else task.apply_async(args=args, kwargs=kwargs,
-                             headers={'periodic_task_name':periodic_task_name})
+            else task.apply_async(
+                args=args,
+                kwargs=kwargs,
+                headers={'periodic_task_name': periodic_task_name}
+            )
             for task, args, kwargs, queue, periodic_task_name in tasks
         ]
         tasks_run = len(task_ids)

--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -248,13 +248,13 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             )
             return
 
-        headers = {'periodic_task_name':periodic_task_name}
 
         task_ids = [
             task.apply_async(args=args, kwargs=kwargs, queue=queue,
-                             headers=headers)
+                             headers={'periodic_task_name':periodic_task_name})
             if queue and len(queue)
-            else task.apply_async(args=args, kwargs=kwargs, headers=headers)
+            else task.apply_async(args=args, kwargs=kwargs,
+                             headers={'periodic_task_name':periodic_task_name})
             for task, args, kwargs, queue, periodic_task_name in tasks
         ]
         tasks_run = len(task_ids)

--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -248,12 +248,13 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
             )
             return
 
+        headers = {'periodic_task_name':periodic_task_name}
+
         task_ids = [
             task.apply_async(args=args, kwargs=kwargs, queue=queue,
-                             periodic_task_name=periodic_task_name)
+                             headers=headers)
             if queue and len(queue)
-            else task.apply_async(args=args, kwargs=kwargs,
-                                  periodic_task_name=periodic_task_name)
+            else task.apply_async(args=args, kwargs=kwargs, headers=headers)
             for task, args, kwargs, queue, periodic_task_name in tasks
         ]
         tasks_run = len(task_ids)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -77,8 +77,9 @@ class ModelEntry(ScheduleEntry):
         if getattr(model, 'expires_', None):
             self.options['expires'] = getattr(model, 'expires_')
 
-        self.options['headers'] = loads(model.headers or '{}')
-        self.options['periodic_task_name'] = model.name
+        headers = loads(model.headers or '{}')
+        headers['periodic_task_name'] = model.name
+        self.options['headers'] = headers
 
         self.total_run_count = model.total_run_count
         self.model = model

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -84,7 +84,7 @@ class ModelEntry(ScheduleEntry):
         self.model = model
 
         if not model.last_run_at:
-            model.last_run_at = self._default_now()
+            model.last_run_at = model.date_changed or self._default_now()
             # if last_run_at is not set and
             # model.start_time last_run_at should be in way past.
             # This will trigger the job to run at start_time

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -130,8 +130,8 @@ class test_ModelEntry(SchedulerCase):
         assert e.options['exchange'] == 'foo'
         assert e.options['routing_key'] == 'cpu'
         assert e.options['priority'] == 1
-        assert e.options['headers'] == {'_schema_name': 'foobar'}
-        assert e.options['periodic_task_name'] == m.name
+        assert e.options['headers']['_schema_name'] == 'foobar'
+        assert e.options['headers']['periodic_task_name'] == m.name
 
         right_now = self.app.now()
         m2 = self.create_model_interval(
@@ -947,3 +947,16 @@ class test_modeladmin_PeriodicTaskAdmin(SchedulerCase):
         assert len(self.request._messages._queued_messages) == 1
         queued_message = self.request._messages._queued_messages[0].message
         assert queued_message == '2 tasks were successfully run'
+
+
+    @pytest.mark.timeout(5)
+    def test_run_task_headers(self, monkeypatch):
+        def mock_apply_async(*args, **kwargs):
+            self.captured_headers = kwargs.get('headers', {})
+
+        monkeypatch.setattr('celery.app.task.Task.apply_async', mock_apply_async)
+        ma = PeriodicTaskAdmin(PeriodicTask, self.site)
+        self.request = self.patch_request(self.request_factory.get('/'))
+        ma.run_tasks(self.request, PeriodicTask.objects.filter(id=self.m1.id))
+        assert 'periodic_task_name' in self.captured_headers
+        assert self.captured_headers['periodic_task_name'] == self.m1.name

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -948,13 +948,13 @@ class test_modeladmin_PeriodicTaskAdmin(SchedulerCase):
         queued_message = self.request._messages._queued_messages[0].message
         assert queued_message == '2 tasks were successfully run'
 
-
     @pytest.mark.timeout(5)
     def test_run_task_headers(self, monkeypatch):
         def mock_apply_async(*args, **kwargs):
             self.captured_headers = kwargs.get('headers', {})
 
-        monkeypatch.setattr('celery.app.task.Task.apply_async', mock_apply_async)
+        monkeypatch.setattr('celery.app.task.Task.apply_async',
+                            mock_apply_async)
         ma = PeriodicTaskAdmin(PeriodicTask, self.site)
         self.request = self.patch_request(self.request_factory.get('/'))
         ma.run_tasks(self.request, PeriodicTask.objects.filter(id=self.m1.id))

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -291,6 +291,35 @@ class test_ModelEntry(SchedulerCase):
         assert not isdue
         assert delay == NEVER_CHECK_TIMEOUT
 
+    def test_task_with_expires(self):
+        interval = 10
+        right_now = self.app.now()
+        one_second_later = right_now + timedelta(seconds=1)
+        m = self.create_model_interval(schedule(timedelta(seconds=interval)),
+                                       start_time=right_now,
+                                       expires=one_second_later)
+        e = self.Entry(m, app=self.app)
+        isdue, delay = e.is_due()
+        assert isdue
+        assert delay == interval
+
+        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
+                                        start_time=right_now,
+                                        expires=right_now)
+        e2 = self.Entry(m2, app=self.app)
+        isdue, delay = e2.is_due()
+        assert not isdue
+        assert delay == NEVER_CHECK_TIMEOUT
+
+        one_second_ago = right_now - timedelta(seconds=1)
+        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
+                                        start_time=right_now,
+                                        expires=one_second_ago)
+        e2 = self.Entry(m2, app=self.app)
+        isdue, delay = e2.is_due()
+        assert not isdue
+        assert delay == NEVER_CHECK_TIMEOUT
+
 
 @pytest.mark.django_db
 class test_DatabaseSchedulerFromAppConf(SchedulerCase):


### PR DESCRIPTION
Fix for issue [#376](https://github.com/celery/django-celery-results/issues/376) in [django-celery-results](https://github.com/celery/django-celery-results/). The message broker rabbitmq isn't picking up `periodic_task_name` when it's passed as a keyword arg to `task.apply_async()`. If it's added to the `headers` in `apply_async()` it becomes available in the `request` object in django-celery-results. For this change to work the following [commit](https://github.com/celery/django-celery-results/commit/8ea61e19689864fbebb81f3552bf669a7150e325) also needs to be merged, otherwise it won't get picked up in the results. 

If the task isn't triggered by django-celery-beat, but is done with code, such as using `delay()` or `apply_async()`, it will be missing, unless it's added to the headers in [`apply_async()`](https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.apply_async). [delay()](https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.delay) doesn't support the extra options. E.g. When triggering a child task with `delay()` Periodic Task Name was missing in the Task Results.

These changes haven't been tested with Redis or any other message broker, only rabbitmq. `CELERY_RESULT_EXTENDED` was set to `True` in the settings.

Tested with: 
celery==5.4.0 
django-celery-beat==2.7.0 
django-celery-results==2.5.1
Django==4.2.16
rabbitmq==4.0.2