### PR TITLE
Add Python 3.13 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,20 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["3.2", "4.2", "5.0", "5.1"]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         exclude:
           - django-version: "3.2"
             python-version: "3.11"
           - django-version: "3.2"
             python-version: "3.12"
-          - django-version: "5.0"
-            python-version: "3.8"
+          - django-version: "3.2"
+            python-version: "3.13"
+          - django-version: "4.2"
+            python-version: "3.13"
           - django-version: "5.0"
             python-version: "3.9"
-          - django-version: "5.1"
-            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.13"
           - django-version: "5.1"
             python-version: "3.9"
 


### PR DESCRIPTION
* https://www.python.org/downloads/release/python-3130/
* https://pythoninsider.blogspot.com/2024/10/python-3130-final-released.html
* https://devguide.python.org/versions/
* https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django