### PR TITLE
add periodic_task_name to headers

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -78,6 +78,7 @@ class ModelEntry(ScheduleEntry):
             self.options['expires'] = getattr(model, 'expires_')
 
         self.options['headers'] = loads(model.headers or '{}')
+        self.options['headers']['periodic_task_name'] = model.name
         self.options['periodic_task_name'] = model.name
 
         self.total_run_count = model.total_run_count

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -130,7 +130,10 @@ class test_ModelEntry(SchedulerCase):
         assert e.options['exchange'] == 'foo'
         assert e.options['routing_key'] == 'cpu'
         assert e.options['priority'] == 1
-        assert e.options['headers'] == {'_schema_name': 'foobar'}
+        assert e.options['headers'] == {
+            '_schema_name': 'foobar',
+            'periodic_task_name': m.name
+        }
         assert e.options['periodic_task_name'] == m.name
 
         right_now = self.app.now()


### PR DESCRIPTION
There is an issue with `periodic_task_name` when using RabbitMQ, in that the field does not appear in the RabbitMQ message as a top-level-property - which is where it is sent in the process by django-celery-beat. This does work when using other Celery message brokers, i.e. Redis. 

The underlying reason is that `periodic_task_name` is not in the list of allowed top-level-properties for AMQP (see [amqp sourcecode](https://github.com/celery/py-amqp/blob/cc10bbe4aea41147356edf39859b349cb4e2de3a/amqp/basic_message.py#L86)) so it gets discarded when passed over to RabbitMQ.

This PR addresses the issue by additionally sending it as a message header.

See also https://github.com/celery/django-celery-results/issues/376