### PR TITLE
Fix the time calculation problem caused by start_time

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -390,8 +390,8 @@ class CrontabSchedule(models.Model):
         except MultipleObjectsReturned:
             return cls.objects.filter(**spec).first()
 
-    def due_start_time(self, start_time, tz):
-        start_time = start_time.astimezone(tz)
+    def due_start_time(self, initial_start_time, tz):
+        start_time = initial_start_time.astimezone(tz)
         start, ends_in, now = self.schedule.remaining_delta(start_time)
         return start + ends_in
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -391,8 +391,7 @@ class CrontabSchedule(models.Model):
             return cls.objects.filter(**spec).first()
 
     def due_start_time(self, start_time, tz):
-        if str(start_time.tzinfo) != str(tz):
-            start_time = start_time.astimezone(tz)
+        start_time = start_time.astimezone(tz)
         start, ends_in, now = self.schedule.remaining_delta(start_time)
         return start + ends_in
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -663,3 +663,11 @@ class PeriodicTask(models.Model):
     @property
     def schedule(self):
         return self.scheduler.schedule
+
+    @property
+    def due_start_time(self):
+        if self.crontab:
+            _, delay = self.scheduler.schedule.is_due(self.start_time)
+            return self.start_time + timedelta(seconds=delay)
+        else:
+            return self.start_time

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -392,9 +392,13 @@ class CrontabSchedule(models.Model):
 
     def due_start_time(self, start_time):
         start, ends_in, now = self.schedule.remaining_delta(start_time)
-        if (str(start.tzinfo) == str(now.tzinfo) and
-            now.utcoffset() != start.utcoffset()):
+
+        same_tz = str(start.tzinfo) == str(now.tzinfo)
+        different_offset = now.utcoffset() != start.utcoffset()
+
+        if same_tz and different_offset:
             start = start.replace(tzinfo=now.tzinfo)
+
         return start + ends_in
 
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -392,8 +392,8 @@ class CrontabSchedule(models.Model):
 
     def due_start_time(self, start_time):
         start, ends_in, now = self.schedule.remaining_delta(start_time)
-        if str(start.tzinfo) == str(
-            now.tzinfo) and now.utcoffset() != start.utcoffset():
+        if (str(start.tzinfo) == str(now.tzinfo) and
+            now.utcoffset() != start.utcoffset()):
             start = start.replace(tzinfo=now.tzinfo)
         return start + ends_in
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -117,9 +117,8 @@ class ModelEntry(ScheduleEntry):
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
 
-                next_time_run = self.schedule.remaining_estimate(
-                    self.model.start_time)
-                delay = math.ceil(next_time_run.total_seconds())
+                delay = math.ceil(
+                    (self.model.due_start_time - now).total_seconds())
 
                 return schedules.schedstate(False, delay)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -116,7 +116,7 @@ class ModelEntry(ScheduleEntry):
             if now < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
-                now_tz = now.tzinfo
+                current_tz = now.tzinfo
                 delay = math.ceil(
                     (self.model.due_start_time(now_tz) - now).total_seconds()
                 )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -117,7 +117,8 @@ class ModelEntry(ScheduleEntry):
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
 
-                next_time_run = self.schedule.remaining_estimate(self.model.start_time) + self.model.start_time
+                next_time_run = self.schedule.remaining_estimate(
+                    self.model.start_time) + self.model.start_time
                 delay = math.ceil((next_time_run - now).total_seconds())
 
                 return schedules.schedstate(False, delay)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -116,9 +116,10 @@ class ModelEntry(ScheduleEntry):
             if now < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
-                delay = math.ceil(
-                    (self.model.start_time - now).total_seconds()
-                )
+
+                next_time_run = self.schedule.remaining_estimate(self.model.start_time) + self.model.start_time
+                delay = math.ceil((next_time_run - now).total_seconds())
+
                 return schedules.schedstate(False, delay)
 
         # EXPIRED TASK: Disable task when expired

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -118,7 +118,7 @@ class ModelEntry(ScheduleEntry):
                 # send a delay to retry on start_time
                 current_tz = now.tzinfo
                 delay = math.ceil(
-                    (self.model.due_start_time(now_tz) - now).total_seconds()
+                    (self.model.due_start_time(current_tz) - now).total_seconds()
                 )
 
                 return schedules.schedstate(False, delay)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -117,9 +117,9 @@ class ModelEntry(ScheduleEntry):
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
                 current_tz = now.tzinfo
-                delay = math.ceil(
-                    (self.model.due_start_time(current_tz) - now).total_seconds()
-                )
+                start_time = self.model.due_start_time(current_tz)
+                time_remaining = start_time - now
+                delay = math.ceil(time_remaining.total_seconds())
 
                 return schedules.schedstate(False, delay)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -118,8 +118,8 @@ class ModelEntry(ScheduleEntry):
                 # send a delay to retry on start_time
 
                 next_time_run = self.schedule.remaining_estimate(
-                    self.model.start_time) + self.model.start_time
-                delay = math.ceil((next_time_run - now).total_seconds())
+                    self.model.start_time)
+                delay = math.ceil(next_time_run.total_seconds())
 
                 return schedules.schedstate(False, delay)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -116,9 +116,9 @@ class ModelEntry(ScheduleEntry):
             if now < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
-
                 delay = math.ceil(
-                    (self.model.due_start_time - now).total_seconds())
+                    (self.model.due_start_time - now).total_seconds()
+                )
 
                 return schedules.schedstate(False, delay)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -116,8 +116,9 @@ class ModelEntry(ScheduleEntry):
             if now < self.model.start_time:
                 # The datetime is before the start date - don't run.
                 # send a delay to retry on start_time
+                now_tz = now.tzinfo
                 delay = math.ceil(
-                    (self.model.due_start_time - now).total_seconds()
+                    (self.model.due_start_time(now_tz) - now).total_seconds()
                 )
 
                 return schedules.schedstate(False, delay)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<9.0
 pytest-timeout
 ephem
+pytz

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<9.0
 pytest-timeout
 ephem
+backports.zoneinfo; python_version < '3.9'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,3 @@ pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<9.0
 pytest-timeout
 ephem
-

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<9.0
 pytest-timeout
 ephem
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,10 @@
-pytest-django>=4.5.2,<5.0
-pytest>=6.2.5,<9.0
-pytest-timeout
+# Base dependencies (common for all Python versions)
 ephem
-backports.zoneinfo; python_version < '3.9'
+pytest-timeout
+
+# Conditional dependencies
+pytest>=6.2.5,<8.0; python_version < '3.9'  # Python 3.8 only
+pytest>=6.2.5,<9.0; python_version >= '3.9'  # Python 3.9+ only
+pytest-django>=4.5.2,<4.6.0; python_version < '3.9'  # Python 3.8 only
+pytest-django>=4.5.2,<5.0; python_version >= '3.9'    # Python 3.9+ only
+backports.zoneinfo; python_version < '3.9'  # Python 3.8 only

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,3 @@ pytest-django>=4.5.2,<5.0
 pytest>=6.2.5,<9.0
 pytest-timeout
 ephem
-pytz

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -4,9 +4,9 @@ import time
 from datetime import datetime, timedelta
 from itertools import count
 from time import monotonic
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from celery.schedules import crontab, schedule, solar
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -831,7 +831,7 @@ class test_DatabaseScheduler(SchedulerCase):
 
         crontab_time = test_start_time + timedelta(minutes=delay_minutes)
 
-        tz = pytz.timezone('Asia/Shanghai')
+        tz = ZoneInfo('Asia/Shanghai')
         test_start_time = test_start_time.astimezone(tz)
 
         task = self.create_model_crontab(
@@ -853,7 +853,7 @@ class test_DatabaseScheduler(SchedulerCase):
 
         test_start_time = crontab_time + timedelta(minutes=delay_minutes)
 
-        tz = pytz.timezone('Asia/Shanghai')
+        tz = ZoneInfo('Asia/Shanghai')
         test_start_time = test_start_time.astimezone(tz)
 
         task = self.create_model_crontab(

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -780,7 +780,6 @@ class test_DatabaseScheduler(SchedulerCase):
 
     def test_crontab_with_start_time_between_now_and_crontab(self, app):
         now = app.now()
-
         delay_minutes = 2
 
         test_start_time = now + timedelta(minutes=delay_minutes)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -4,7 +4,11 @@ import time
 from datetime import datetime, timedelta
 from itertools import count
 from time import monotonic
-from zoneinfo import ZoneInfo
+
+try:
+    from zoneinfo import ZoneInfo  # Python 3.9+
+except ImportError:
+    from backports.zoneinfo import ZoneInfo  # Python 3.8
 
 import pytest
 from celery.schedules import crontab, schedule, solar

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -892,7 +892,9 @@ class test_DatabaseScheduler(SchedulerCase):
         e2 = EntryTrackSave(m2, app=self.app)
         is_due, _ = e2.is_due()
 
-        while (not is_due):
+        max_iterations = 1000
+        iterations = 0
+        while (not is_due and iterations < max_iterations):
             s.tick()
             assert s._heap[0][2].name != m2.name
             is_due, _ = e2.is_due()


### PR DESCRIPTION
### Description  
This PR fixes a critical scheduling issue in `django-celery-beat` when a **crontab-type task** is configured with a `start_time` set to a future time.  

#### Problem Analysis  
- When initializing the scheduler's heap (`self._heap`), tasks are sorted by their `event_t.time` field.  
- For crontab tasks with `start_time > now`, the initial `event_t.time` was incorrectly set to `start_time` instead of the **next valid execution time** based on the crontab schedule.  
- This caused the task to persistently occupy the heap's top position (since `start_time` was the smallest future timestamp), blocking other tasks from being executed until the `start_time` was reached.  

#### Solution  
- **Modified the `event_t.time` generation logic** during heap initialization for crontab tasks with future `start_time` values.  
- Instead of directly using `start_time`, the `event_t.time` is now calculated as the **next valid execution time** derived from the crontab schedule **relative to `start_time`**.  
  - Example: If a task is set to run every hour (`0 * * * *`) with `start_time=2024-01-01 12:00:00` (future time), the initial `event_t.time` will be `2024-01-01 12:00:00` (first valid run) instead of the current time.  
- Ensures the heap prioritizes tasks based on their **actual next execution time** rather than `start_time`, preventing heap blockage.  

#### Changes
- Enhanced the `is_due` method in `schedulers.py` to:
  - Add special handling for tasks with non-null `start_time`
  
#### Expected Behavior  
- Tasks with future `start_time` will no longer block the scheduler heap.  
- The heap now correctly prioritizes tasks based on their dynamically calculated next execution time, allowing other interval/crontab tasks to execute as expected.  

fixes https://github.com/celery/django-celery-beat/issues/843