### PR TITLE
feat(admin): add task field to search_fields

### DIFF
--- a/django_celery_beat/admin.py
+++ b/django_celery_beat/admin.py
@@ -118,7 +118,7 @@ class PeriodicTaskAdmin(admin.ModelAdmin):
                     'last_run_at', 'one_off')
     list_filter = ['enabled', 'one_off', 'task', 'start_time', 'last_run_at']
     actions = ('enable_tasks', 'disable_tasks', 'toggle_tasks', 'run_tasks')
-    search_fields = ('name',)
+    search_fields = ('name', 'task',)
     fieldsets = (
         (None, {
             'fields': ('name', 'regtask', 'task', 'enabled', 'description',),


### PR DESCRIPTION
Extended the search functionality in the PeriodicTaskAdmin by adding 'task' to the search_fields. This allows users to search periodic tasks by their task names, improving the admin interface usability.

Issue: https://github.com/celery/django-celery-beat/issues/856