### PR TITLE
fix(tests): correct assertion in excluded hours test

### DIFF
--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -540,8 +540,7 @@ class test_DatabaseScheduler(SchedulerCase):
         assert str(now_hour) not in excluded_hours
         assert str((now_hour + 1) % 24) not in excluded_hours
         assert str((now_hour - 1) % 24) not in excluded_hours
-        assert str((now_hour + 2) % 24) in excluded_hours
-        assert str((now_hour - 2) % 24) in excluded_hours
+        assert str(4) not in excluded_hours
 
     def test_schedule_changed(self):
         self.m2.args = '[16, 16]'


### PR DESCRIPTION
The `test_get_excluded_hours_for_crontab_tasks` method had assertions for excluded hours that could fail depending on the test execution time. We can only guarantee what hours are not returned by `test_get_excluded_hours_for_crontab_tasks` and have amended the test to do so.