### PR TITLE
pre-commit: Upgrade to ruff v0.11.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.1
+    rev: v0.11.2
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         args: [--target-version, "3.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.1
     hooks:  # Format before linting
       # - id: ruff-format
       - id: ruff

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -395,7 +395,7 @@ class DatabaseScheduler(Scheduler):
     def get_excluded_hours_for_crontab_tasks():
         # Generate the full list of allowed hours for crontabs
         allowed_crontab_hours = [
-            str(hour).zfill(2) for hour in range(24)
+            f"{hour:02}" for hour in range(24)
         ] + [
             str(hour) for hour in range(10)
         ]
@@ -408,9 +408,9 @@ class DatabaseScheduler(Scheduler):
 
         # Create a set of hours to remove (both padded and non-padded versions)
         hours_to_remove = {
-            str(current_hour).zfill(2), str(current_hour),
-            str(next_hour).zfill(2), str(next_hour),
-            str(previous_hour).zfill(2), str(previous_hour),
+            f"{current_hour:02}", str(current_hour),
+            f"{next_hour:02}", str(next_hour),
+            f"{previous_hour:02}", str(previous_hour),
             str(4), "04",  # celery's default cleanup task
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ lint.ignore = [
   "N803",
   "N806",
   "PIE790",
-  "PT004",
   "PT009",
   "PT027",
   "UP031",
@@ -82,6 +81,7 @@ lint.per-file-ignores."*/migrations/*" = [
   "D",
   "E501",
   "I",
+  "PGH004",
 ]
 lint.per-file-ignores."django_celery_beat/models.py" = [
   "ISC002",


### PR DESCRIPTION
% [`ruff rule PGH004`](https://docs.astral.sh/ruff/rules/blanket-noqa) objects to `# flake8: noqa` lines in our migrations files but those lines are correct.

Also,
> warning: The following rules have been removed and ignoring them has no effect:
>    - PT004