### PR TITLE
Set all the python/django version numbers correctly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         python -m pip install tox tox-gh-actions
     - name: Test with tox
       run: |
-        if [ "${{ matrix.python-version }}" != "pypy-3.10" ]; then
+        if [ "${{ matrix.python-version }}" != "pypy-3.11" ]; then
           tox -- --cov=django_celery_beat --cov-report=xml --no-cov-on-fail --cov-report term
         else
           tox
@@ -52,7 +52,7 @@ jobs:
       env:
         DJANGO: ${{ matrix.django-version }}
     - name: Upload coverage reports to Codecov
-      if: ${{ matrix.python-version != 'pypy-3.10' }}
+      if: ${{ matrix.python-version != 'pypy-3.11' }}
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["4.2", "5.0", "5.1", "5.2rc1"]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
         exclude:
           - django-version: "4.2"
             python-version: "3.13"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
-        django-version: ["3.2", "4.2", "5.0", "5.1", "5.2rc1"]
+        django-version: ["4.2", "5.0", "5.1", "5.2rc1"]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         exclude:
-          - django-version: "3.2"
-            python-version: "3.11"
-          - django-version: "3.2"
-            python-version: "3.12"
-          - django-version: "3.2"
-            python-version: "3.13"
           - django-version: "4.2"
             python-version: "3.13"
           - django-version: "5.0"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.12"
 sphinx:
    configuration: docs/conf.py
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,8 @@
 version: 2
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
-    python: "3.12"
+    python: "3"
 sphinx:
    configuration: docs/conf.py
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-latest
   tools:
     python: "3.12"
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 
 lint.select = [
   "A",     # flake8-builtins

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,18 @@ classes = """
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Framework :: Django :: 5.1
+    Framework :: Django :: 5.2
     Operating System :: OS Independent
     Topic :: Communications
     Topic :: System :: Distributed Computing
@@ -116,7 +115,7 @@ setuptools.setup(
     url=meta['homepage'],
     platforms=['any'],
     license='BSD',
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=reqs('default.txt') + reqs('runtime.txt'),
     classifiers=classifiers,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
-    pypy-3.10: pypy3
+    pypy-3.11: pypy3
 
 [gh-actions:env]
 DJANGO =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
     pypy-3.10: pypy3
 
 [gh-actions:env]
@@ -16,15 +17,16 @@ DJANGO =
     4.2: django42
     5.0: django50
     5.1: django51
+    5.2rc1: django52
 
 [tox]
 envlist =
-    py38-django{32,42}
     py39-django{32,42}
-    py310-django{32,42,50,51}
-    py311-django{42,50,51}
-    py312-django{42,50,51}
-    pypy3-django{32,42,50,51}
+    py310-django{32,42,50,51,52}
+    py311-django{42,50,51,52}
+    py312-django{42,50,51,52}
+    py313-django{51,52}
+    pypy3-django{32,42,50,51,52}
     flake8
     apicheck
     linkcheck
@@ -43,7 +45,8 @@ deps=
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0
-	django51: Django ~= 5.1rc1
+	django51: Django ~= 5.1
+	django52: Django ~= 5.2rc1
 
     linkcheck,apicheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
@@ -55,12 +58,12 @@ commands =
 
 
 [testenv:apicheck]
-basepython = python3.8
+basepython = python3.9
 commands =
     sphinx-build -W -b apicheck -d {envtmpdir}/doctrees docs docs/_build/apicheck
 
 [testenv:linkcheck]
-basepython = python3.8
+basepython = python3.9
 commands =
     sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 
 [gh-actions]
 python =
-    3.8: py38, apicheck, linkcheck
-    3.9: py39, flake8, pydocstyle, cov
+    3.9: py39, flake8, pydocstyle, cov, apicheck, linkcheck
     3.10: py310
     3.11: py311
     3.12: py312
@@ -12,8 +11,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
-    4.1: django41
     4.2: django42
     5.0: django50
     5.1: django51
@@ -21,12 +18,12 @@ DJANGO =
 
 [tox]
 envlist =
-    py39-django{32,42}
-    py310-django{32,42,50,51,52}
+    py39-django{42}
+    py310-django{42,50,51,52}
     py311-django{42,50,51,52}
     py312-django{42,50,51,52}
     py313-django{51,52}
-    pypy3-django{32,42,50,51,52}
+    pypy3-django{42,50,51,52}
     flake8
     apicheck
     linkcheck
@@ -41,7 +38,6 @@ deps=
 
     cov: -r{toxinidir}/requirements/test-django.txt
 
-	django32: Django ~= 3.2
 	django41: Django ~= 4.1
 	django42: Django ~= 4.2
 	django50: Django ~= 5.0


### PR DESCRIPTION
- [x] remove reference to django 3.2, 4.1, 4.2 (EOL)
- [x] remove python 3.8 (EOL)
- [x] replace pypy-3.10 with pypy-3.11
- [x] add django 5.2rc1 to tox
- [x] make sure tools runs with 3.9 
- [x] tell readthedocs to use latest python and ubuntu lts