### PR TITLE
Refactor / all_as_schedule crontab query optimization

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -289,7 +289,9 @@ class DatabaseScheduler(Scheduler):
         server-equivalent hour, then filters on that annotation.
         """
         # Get server time
-        server_time = now()
+        server_time = timezone.localtime(
+            datetime.datetime.now(datetime.timezone.utc)
+        )
         server_hour = server_time.hour
 
         # Previous, current, and next hour in server timezone

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -4,6 +4,11 @@ import logging
 import math
 from multiprocessing.util import Finalize
 
+try:
+    from zoneinfo import ZoneInfo  # Python 3.9+
+except ImportError:
+    from backports.zoneinfo import ZoneInfo  # Python 3.8
+
 from celery import current_app, schedules
 from celery.beat import ScheduleEntry, Scheduler
 from celery.utils.log import get_logger
@@ -363,7 +368,7 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         server_tz = timezone.get_current_timezone()
 
-        target_tz = timezone_name
+        target_tz = ZoneInfo(timezone_name)
 
         # Use a fixed point in time for the calculation to avoid DST issues
         fixed_dt = datetime.datetime(2023, 1, 1, 12, 0, 0)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -296,14 +296,8 @@ class DatabaseScheduler(Scheduler):
         server_hour = server_time.hour
 
         # Window of +/- 2 hours around the current hour in server tz.
-        hours_to_include = [
-            (server_hour - 2) % 24,
-            (server_hour - 1) % 24,
-            server_hour,
-            (server_hour + 1) % 24,
-            (server_hour + 2) % 24,
-            4,                       # hour 4 (celery's default cleanup task)
-        ]
+        hours_to_include = [(server_hour + offset) % 24 for offset in range(-2, 3)]
+        hours_to_include += [4]  # celery's default cleanup task
 
         # Regex pattern to match only numbers
         # This ensures we only process numeric hour values

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -368,6 +368,9 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         server_tz = timezone.get_current_timezone()
 
+        if isinstance(timezone_name, ZoneInfo):
+            timezone_name = timezone_name.key
+
         target_tz = ZoneInfo(timezone_name)
 
         # Use a fixed point in time for the calculation to avoid DST issues

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -26,7 +26,7 @@ from kombu.utils.json import dumps, loads
 from .clockedschedule import clocked
 from .models import (ClockedSchedule, CrontabSchedule, IntervalSchedule,
                      PeriodicTask, PeriodicTasks, SolarSchedule)
-from .utils import NEVER_CHECK_TIMEOUT, now
+from .utils import NEVER_CHECK_TIMEOUT, now, aware_now
 
 # This scheduler must wake up more frequently than the
 # regular of 5 minutes because it needs to take external
@@ -291,10 +291,9 @@ class DatabaseScheduler(Scheduler):
         This creates an annotation for each crontab task that represents the
         server-equivalent hour, then filters on that annotation.
         """
-        # Get server time
-        server_time = timezone.localtime(
-            datetime.datetime.now(datetime.timezone.utc)
-        )
+        # Get server time based on Django settings
+
+        server_time = aware_now()
         server_hour = server_time.hour
 
         # Window of +/- 2 hours around the current hour in server tz.

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -383,7 +383,6 @@ class DatabaseScheduler(Scheduler):
         offset_seconds = (dt1.utcoffset().total_seconds() - dt2.utcoffset().total_seconds())
         offset_hours = int(offset_seconds / 3600)
 
-        print(offset_hours)
         return offset_hours
 
     def schedule_changed(self):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -260,18 +260,131 @@ class DatabaseScheduler(Scheduler):
         exclude_clock_tasks_query = Q(
             clocked__isnull=False, clocked__clocked_time__gt=next_five_minutes
         )
-        exclude_hours = self.get_excluded_hours_for_crontab_tasks()
-        exclude_cron_tasks_query = Q(
-            crontab__isnull=False, crontab__hour__in=exclude_hours
-        )
-        for model in self.Model.objects.enabled().exclude(
-            exclude_clock_tasks_query | exclude_cron_tasks_query
-        ):
+
+        # Get hours to exclude based on crontab tasks with timezone-adjusted server hour
+        exclude_cron_tasks_query = self._get_crontab_exclude_query()
+
+        # Combine the queries for optimal database filtering
+        exclude_query = exclude_clock_tasks_query | exclude_cron_tasks_query
+
+        # Fetch only the tasks we need to consider
+        for model in self.Model.objects.enabled().exclude(exclude_query):
             try:
                 s[model.name] = self.Entry(model, app=self.app)
             except ValueError:
                 pass
         return s
+
+    def _get_crontab_exclude_query(self):
+        """
+        Build a query to exclude crontab tasks based on their hour value,
+        adjusted for timezone differences relative to the server.
+
+        This creates an annotation for each crontab task that represents the
+        server-equivalent hour, then filters on that annotation.
+        """
+        # Get server time and timezone
+        server_time = timezone.localtime(now())
+        server_hour = server_time.hour
+
+        # Previous, current, and next hour in server timezone
+        hours_to_include = [
+            (server_hour - 2) % 24,
+            (server_hour - 1) % 24,
+            server_hour,
+            (server_hour + 1) % 24,
+            (server_hour + 2) % 24,
+            4,                       # hour 4 (celery's default cleanup task)
+        ]
+
+        # Create a query for tasks with specific hour values only
+        # This is where we'll do the timezone conversion
+        from django.db.models.functions import Cast
+        from django.db.models import F, IntegerField, Case, When
+
+        # Regex pattern to match only numbers
+        # This ensures we only process numeric hour values
+        numeric_hour_pattern = r'^\d+$'
+
+        # Get all tasks with a simple numeric hour value
+        numeric_hour_tasks = CrontabSchedule.objects.filter(hour__regex=numeric_hour_pattern)
+
+        # Annotate these tasks with their server-hour equivalent
+        annotated_tasks = numeric_hour_tasks.annotate(
+            # Cast hour string to integer
+            hour_int=Cast('hour', IntegerField()),
+
+            # Calculate server-hour based on timezone offset
+            server_hour=Case(
+                # Handle each timezone specifically
+                *[
+                    When(
+                        timezone=timezone_name,
+                        then=(F('hour_int') + self._get_timezone_offset(timezone_name)) % 24
+                    )
+                    for timezone_name in self._get_unique_timezone_names()
+                ],
+                # Default case - use hour as is
+                default=F('hour_int')
+            )
+        )
+
+        # Get IDs of tasks whose server_hour falls not within our include window
+        excluded_hour_task_ids = annotated_tasks.exclude(
+            server_hour__in=hours_to_include
+        ).values_list('id', flat=True)
+
+        # Build the final exclude query:
+        # Exclude crontab tasks that are not in our include list
+        exclude_query = Q(crontab__isnull=False) & Q(crontab__id__in=excluded_hour_task_ids)
+
+        return exclude_query
+
+    def _get_unique_timezone_names(self):
+        """Get a list of all unique timezone names used in CrontabSchedule"""
+        return CrontabSchedule.objects.values_list('timezone', flat=True).distinct()
+
+    def _get_timezone_offset(self, timezone_name):
+        """
+        Calculate the hour offset between the given timezone and server timezone.
+
+        Args:
+            timezone_name: The name of the timezone or a ZoneInfo object
+
+        Returns:
+            int: The hour offset to add to convert from timezone's hour to server hour
+        """
+        # Get server timezone
+        server_tz = timezone.get_current_timezone()
+
+        # Handle the timezone_name input
+        if hasattr(timezone_name, 'key'):  # ZoneInfo object
+            target_tz = timezone_name
+        else:
+            # Get target timezone
+            import pytz
+            try:
+                if isinstance(timezone_name, str) and timezone_name.upper() == 'UTC':
+                    target_tz = pytz.UTC
+                else:
+                    target_tz = pytz.timezone(str(timezone_name))
+            except pytz.exceptions.UnknownTimeZoneError:
+                # If timezone is unknown, assume no offset
+                return 0
+
+        # Use a fixed point in time for the calculation to avoid DST issues
+        fixed_dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+        # Calculate the offset
+        dt1 = fixed_dt.replace(tzinfo=server_tz)
+        dt2 = fixed_dt.replace(tzinfo=target_tz)
+
+        # Calculate hour difference
+        offset_seconds = (dt1.utcoffset().total_seconds() - dt2.utcoffset().total_seconds())
+        offset_hours = int(offset_seconds / 3600)
+
+        print(offset_hours)
+        return offset_hours
 
     def schedule_changed(self):
         try:
@@ -392,32 +505,3 @@ class DatabaseScheduler(Scheduler):
                     repr(entry) for entry in self._schedule.values()),
                 )
         return self._schedule
-
-    @staticmethod
-    def get_excluded_hours_for_crontab_tasks():
-        # Generate the full list of allowed hours for crontabs
-        allowed_crontab_hours = [
-            f"{hour:02}" for hour in range(24)
-        ] + [
-            str(hour) for hour in range(10)
-        ]
-
-        # Get current, next, and previous hours
-        current_time = timezone.localtime(now())
-        current_hour = current_time.hour
-        next_hour = (current_hour + 1) % 24
-        previous_hour = (current_hour - 1) % 24
-
-        # Create a set of hours to remove (both padded and non-padded versions)
-        hours_to_remove = {
-            f"{current_hour:02}", str(current_hour),
-            f"{next_hour:02}", str(next_hour),
-            f"{previous_hour:02}", str(previous_hour),
-            str(4), "04",  # celery's default cleanup task
-        }
-
-        # Filter out 'should be considered' hours
-        return [
-            hour for hour in allowed_crontab_hours
-            if hour not in hours_to_remove
-        ]

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -296,7 +296,9 @@ class DatabaseScheduler(Scheduler):
         server_hour = server_time.hour
 
         # Window of +/- 2 hours around the current hour in server tz.
-        hours_to_include = [(server_hour + offset) % 24 for offset in range(-2, 3)]
+        hours_to_include = [
+            (server_hour + offset) % 24 for offset in range(-2, 3)
+        ]
         hours_to_include += [4]  # celery's default cleanup task
 
         # Regex pattern to match only numbers

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -16,7 +16,8 @@ from celery.utils.time import maybe_make_aware
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import close_old_connections, transaction
-from django.db.models import Q
+from django.db.models import Q, Case, F, IntegerField, When
+from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
 from django.utils import timezone
 from kombu.utils.encoding import safe_repr, safe_str
@@ -303,11 +304,6 @@ class DatabaseScheduler(Scheduler):
             (server_hour + 2) % 24,
             4,                       # hour 4 (celery's default cleanup task)
         ]
-
-        # Create a query for tasks with specific hour values only
-        # This is where we'll do the timezone conversion
-        from django.db.models import Case, F, IntegerField, When
-        from django.db.models.functions import Cast
 
         # Regex pattern to match only numbers
         # This ensures we only process numeric hour values

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -264,10 +264,12 @@ class DatabaseScheduler(Scheduler):
     def all_as_schedule(self):
         debug('DatabaseScheduler: Fetching database schedule')
         s = {}
-        next_five_minutes = now() + datetime.timedelta(minutes=5)
+        next_schedule_sync = now() + datetime.timedelta(
+            seconds=SCHEDULE_SYNC_MAX_INTERVAL
+        )
         exclude_clock_tasks_query = Q(
             clocked__isnull=False,
-            clocked__clocked_time__gt=next_five_minutes
+            clocked__clocked_time__gt=next_schedule_sync
         )
 
         exclude_cron_tasks_query = self._get_crontab_exclude_query()

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -288,8 +288,8 @@ class DatabaseScheduler(Scheduler):
         This creates an annotation for each crontab task that represents the
         server-equivalent hour, then filters on that annotation.
         """
-        # Get server time and timezone
-        server_time = timezone.localtime(now())
+        # Get server time
+        server_time = now()
         server_hour = server_time.hour
 
         # Previous, current, and next hour in server timezone

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -18,10 +18,8 @@ from kombu.utils.encoding import safe_repr, safe_str
 from kombu.utils.json import dumps, loads
 
 from .clockedschedule import clocked
-from .models import (
-    ClockedSchedule, CrontabSchedule, IntervalSchedule,
-    PeriodicTask, PeriodicTasks, SolarSchedule
-)
+from .models import (ClockedSchedule, CrontabSchedule, IntervalSchedule,
+                     PeriodicTask, PeriodicTasks, SolarSchedule)
 from .utils import NEVER_CHECK_TIMEOUT, now
 
 # This scheduler must wake up more frequently than the
@@ -260,12 +258,10 @@ class DatabaseScheduler(Scheduler):
         s = {}
         next_five_minutes = now() + datetime.timedelta(minutes=5)
         exclude_clock_tasks_query = Q(
-            clocked__isnull=False, 
+            clocked__isnull=False,
             clocked__clocked_time__gt=next_five_minutes
         )
 
-        # Get hours to exclude based on crontab tasks with 
-        # timezone-adjusted server hour
         exclude_cron_tasks_query = self._get_crontab_exclude_query()
 
         # Combine the queries for optimal database filtering
@@ -327,8 +323,8 @@ class DatabaseScheduler(Scheduler):
                     When(
                         timezone=timezone_name,
                         then=(
-                            F('hour_int') + 
-                            self._get_timezone_offset(timezone_name)
+                            F('hour_int')
+                            + self._get_timezone_offset(timezone_name)
                         ) % 24
                     )
                     for timezone_name in self._get_unique_timezone_names()
@@ -338,8 +334,6 @@ class DatabaseScheduler(Scheduler):
             )
         )
 
-        # Get IDs of tasks whose server_hour falls not within our 
-        # include window
         excluded_hour_task_ids = annotated_tasks.exclude(
             server_hour__in=hours_to_include
         ).values_list('id', flat=True)
@@ -360,15 +354,11 @@ class DatabaseScheduler(Scheduler):
 
     def _get_timezone_offset(self, timezone_name):
         """
-        Calculate the hour offset between the given timezone and server 
-        timezone.
-
         Args:
             timezone_name: The name of the timezone or a ZoneInfo object
 
         Returns:
-            int: The hour offset to add to convert from timezone's hour 
-                to server hour
+            int: The hour offset
         """
         # Get server timezone
         server_tz = timezone.get_current_timezone()
@@ -380,8 +370,10 @@ class DatabaseScheduler(Scheduler):
             # Get target timezone
             import pytz
             try:
-                if (isinstance(timezone_name, str) and 
-                        timezone_name.upper() == 'UTC'):
+                if (
+                    isinstance(timezone_name, str)
+                    and timezone_name.upper() == 'UTC'
+                ):
                     target_tz = pytz.UTC
                 else:
                     target_tz = pytz.timezone(str(timezone_name))

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -325,6 +325,7 @@ class DatabaseScheduler(Scheduler):
                         then=(
                             F('hour_int')
                             + self._get_timezone_offset(timezone_name)
+                            + 24
                         ) % 24
                     )
                     for timezone_name in self._get_unique_timezone_names()

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -295,7 +295,7 @@ class DatabaseScheduler(Scheduler):
         )
         server_hour = server_time.hour
 
-        # Previous, current, and next hour in server timezone
+        # Window of +/- 2 hours around the current hour in server tz.
         hours_to_include = [
             (server_hour - 2) % 24,
             (server_hour - 1) % 24,

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -299,8 +299,8 @@ class DatabaseScheduler(Scheduler):
 
         # Create a query for tasks with specific hour values only
         # This is where we'll do the timezone conversion
+        from django.db.models import Case, F, IntegerField, When
         from django.db.models.functions import Cast
-        from django.db.models import F, IntegerField, Case, When
 
         # Regex pattern to match only numbers
         # This ensures we only process numeric hour values

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -363,23 +363,7 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         server_tz = timezone.get_current_timezone()
 
-        # Handle the timezone_name input
-        if hasattr(timezone_name, 'key'):  # ZoneInfo object
-            target_tz = timezone_name
-        else:
-            # Get target timezone
-            import pytz
-            try:
-                if (
-                    isinstance(timezone_name, str)
-                    and timezone_name.upper() == 'UTC'
-                ):
-                    target_tz = pytz.UTC
-                else:
-                    target_tz = pytz.timezone(str(timezone_name))
-            except pytz.exceptions.UnknownTimeZoneError:
-                # If timezone is unknown, assume no offset
-                return 0
+        target_tz = timezone_name
 
         # Use a fixed point in time for the calculation to avoid DST issues
         fixed_dt = datetime.datetime(2023, 1, 1, 12, 0, 0)

--- a/django_celery_beat/utils.py
+++ b/django_celery_beat/utils.py
@@ -1,10 +1,18 @@
 """Utilities."""
+import datetime
 # -- XXX This module must not use translation as that causes
 # -- a recursive loader import!
 from datetime import timezone as datetime_timezone
 
+try:
+    from zoneinfo import ZoneInfo  # Python 3.9+
+except ImportError:
+    from backports.zoneinfo import ZoneInfo  # Python 3.8
+
 from django.conf import settings
 from django.utils import timezone
+
+
 
 is_aware = timezone.is_aware
 # celery schedstate return None will make it not work
@@ -35,6 +43,16 @@ def now():
         return now_localtime(timezone.now())
     else:
         return timezone.now()
+
+
+def aware_now():
+    if getattr(settings, 'USE_TZ', True):
+        # When USE_TZ is True, return timezone.now()
+        return timezone.now()
+    else:
+        # When USE_TZ is False, use the project's timezone
+        project_tz = ZoneInfo(getattr(settings, 'TIME_ZONE', 'UTC'))
+        return datetime.datetime.now(project_tz)
 
 
 def is_database_scheduler(scheduler):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1030,13 +1030,8 @@ class test_DatabaseScheduler(SchedulerCase):
         # Set up mocks for server timezone and current time
         from datetime import datetime
 
-        # Use zoneinfo instead of pytz for Django 4.2+
-        try:
-            from zoneinfo import ZoneInfo
-            server_tz = ZoneInfo("Asia/Tokyo")
-        except ImportError:
-            import pytz
-            server_tz = pytz.timezone("Asia/Tokyo")
+        from zoneinfo import ZoneInfo
+        server_tz = ZoneInfo("Asia/Tokyo")
 
         mock_get_tz.return_value = server_tz
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1060,19 +1060,18 @@ class test_DatabaseScheduler(SchedulerCase):
         assert task_hour_four.id not in excluded_tasks
 
     @pytest.mark.django_db
+    @patch('django_celery_beat.utils.aware_now')
     @patch('django.utils.timezone.get_current_timezone')
-    @patch('django.utils.timezone.now')
-    def test_crontab_timezone_conversion(self, mock_now, mock_get_tz):
+    def test_crontab_timezone_conversion(self, mock_get_tz, mock_aware_now):
         # Set up mocks for server timezone and current time
         from datetime import datetime
-
         server_tz = ZoneInfo("Asia/Tokyo")
 
         mock_get_tz.return_value = server_tz
 
         # Server time is 17:00 Tokyo time
         mock_now_dt = datetime(2023, 1, 1, 17, 0, 0, tzinfo=server_tz)
-        mock_now.return_value = mock_now_dt
+        mock_aware_now.return_value = mock_now_dt
 
         # Create tasks with the following crontab schedules:
         # 1. UTC task at hour 8 - equivalent to 17:00 Tokyo time (current hour)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1004,8 +1004,9 @@ class test_DatabaseScheduler(SchedulerCase):
         This test mocks the server timezone to Tokyo and tests timezone conversions.
         """
         # Set up mocks for server timezone and current time
-        import pytz
         from datetime import datetime
+
+        import pytz
 
         # Server timezone is Tokyo (UTC+9)
         server_tz = pytz.timezone("Asia/Tokyo")

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -910,13 +910,6 @@ class test_DatabaseScheduler(SchedulerCase):
 
     @pytest.mark.django_db
     def test_crontab_exclusion_logic_basic(self):
-        """
-        Test that the crontab exclusion logic properly excludes schedules 
-        outside the time window.
-        This is a simple test without timezone complications.
-        """
-        # Create crontab schedules with simple hour values in the 
-        # default timezone
         current_hour = datetime.now().hour
         cron_current_hour = CrontabSchedule.objects.create(
             hour=str(current_hour)
@@ -1001,8 +994,6 @@ class test_DatabaseScheduler(SchedulerCase):
                         task_minus_one.id, task_minus_two.id]:
             assert task_id not in excluded_tasks
 
-        # The task outside our time window should be excluded if it's not 
-        # hour 4
         if task_outside.crontab.hour != '4':
             assert task_outside.id in excluded_tasks
 
@@ -1036,12 +1027,6 @@ class test_DatabaseScheduler(SchedulerCase):
     @patch('django.utils.timezone.get_current_timezone')
     @patch('django.utils.timezone.now')
     def test_crontab_timezone_conversion(self, mock_now, mock_get_tz):
-        """
-        Test that the scheduler correctly handles crontab schedules with 
-        different timezones.
-        This test mocks the server timezone to Tokyo and tests timezone 
-        conversions.
-        """
         # Set up mocks for server timezone and current time
         from datetime import datetime
 
@@ -1052,13 +1037,13 @@ class test_DatabaseScheduler(SchedulerCase):
         except ImportError:
             import pytz
             server_tz = pytz.timezone("Asia/Tokyo")
-            
+
         mock_get_tz.return_value = server_tz
-        
+
         # Server time is 17:00 Tokyo time
         mock_now_dt = datetime(2023, 1, 1, 17, 0, 0, tzinfo=server_tz)
         mock_now.return_value = mock_now_dt
-        
+
         # Create tasks with the following crontab schedules:
         # 1. UTC task at hour 8 - equivalent to 17:00 Tokyo time (current hour)
         #    - should be included
@@ -1066,7 +1051,7 @@ class test_DatabaseScheduler(SchedulerCase):
         #    (current hour) - should be included
         # 3. UTC task at hour 3 - equivalent to 12:00 Tokyo time
         #    - should be excluded (outside window)
-        
+
         # Create crontab schedules in different timezones
         utc_current_hour = CrontabSchedule.objects.create(
             hour='8', timezone='UTC'
@@ -1267,7 +1252,7 @@ class test_models(SchedulerCase):
         assert s.schedule is not None
         isdue, nextcheck = s.schedule.is_due(dt_lastrun)
         # False means task isn't due, but keep checking.
-        assert isdue is False  
+        assert isdue is False
         assert (nextcheck > 0) and (isdue is False) or \
             (nextcheck == s.max_interval) and (isdue is True)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1060,7 +1060,7 @@ class test_DatabaseScheduler(SchedulerCase):
         assert task_hour_four.id not in excluded_tasks
 
     @pytest.mark.django_db
-    @patch('django_celery_beat.utils.aware_now')
+    @patch('django_celery_beat.schedulers.aware_now')
     @patch('django.utils.timezone.get_current_timezone')
     def test_crontab_timezone_conversion(self, mock_get_tz, mock_aware_now):
         # Set up mocks for server timezone and current time
@@ -1136,9 +1136,9 @@ class test_DatabaseScheduler(SchedulerCase):
 
     @pytest.mark.django_db
     @patch('django.utils.timezone.get_current_timezone')
-    @patch('django.utils.timezone.now')
+    @patch('django_celery_beat.schedulers.aware_now')
     def test_crontab_timezone_conversion_with_negative_offset_and_dst(
-        self, mock_now, mock_get_tz
+        self, mock_aware_now, mock_get_tz
     ):
         # Set up mocks for server timezone and current time
         from datetime import datetime
@@ -1149,7 +1149,7 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # Server time is 17:00 UTC in June
         mock_now_dt = datetime(2023, 6, 1, 17, 0, 0, tzinfo=server_tz)
-        mock_now.return_value = mock_now_dt
+        mock_aware_now.return_value = mock_now_dt
 
         # Create tasks with the following crontab schedules:
         # 1. Asia/Tokyo task at hour 2 - equivalent to 17:00 UTC (current hour)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1030,7 +1030,6 @@ class test_DatabaseScheduler(SchedulerCase):
         # Set up mocks for server timezone and current time
         from datetime import datetime
 
-        from zoneinfo import ZoneInfo
         server_tz = ZoneInfo("Asia/Tokyo")
 
         mock_get_tz.return_value = server_tz

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -573,8 +573,7 @@ class test_DatabaseScheduler(SchedulerCase):
         is_hour_four_task = False
 
         # Check if the task would have hour 4.
-        if self.m11.crontab.hour == '4'\
-        or (current_hour + 3) % 24 == 4:
+        if self.m11.crontab.hour == '4' or (current_hour + 3) % 24 == 4:
             is_hour_four_task = True
 
         # Add to expected tasks if it's an hour=4 task

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -534,7 +534,7 @@ class test_DatabaseScheduler(SchedulerCase):
     def test_all_as_schedule(self):
         sched = self.s.schedule
         assert sched
-        assert len(sched) == 9
+        assert len(sched) == 10
         assert 'celery.backend_cleanup' in sched
         for n, e in sched.items():
             assert isinstance(e, self.s.Entry)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -307,40 +307,50 @@ class test_ModelEntry(SchedulerCase):
         interval = 10
         right_now = self.app.now()
         one_interval_ago = right_now - timedelta(seconds=interval)
-        m = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                       start_time=right_now,
-                                       last_run_at=one_interval_ago)
+        m = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            start_time=right_now,
+            last_run_at=one_interval_ago
+        )
         e = self.Entry(m, app=self.app)
         isdue, delay = e.is_due()
         assert isdue
         assert delay == interval
 
         tomorrow = right_now + timedelta(days=1)
-        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                        start_time=tomorrow,
-                                        last_run_at=one_interval_ago)
+        m2 = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            start_time=tomorrow,
+            last_run_at=one_interval_ago
+        )
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue
-        assert delay == math.ceil((tomorrow - right_now).total_seconds())
+        assert delay == math.ceil(
+            (tomorrow - right_now).total_seconds()
+        )
 
     def test_one_off_task(self):
         interval = 10
         right_now = self.app.now()
         one_interval_ago = right_now - timedelta(seconds=interval)
-        m = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                       one_off=True,
-                                       last_run_at=one_interval_ago,
-                                       total_run_count=0)
+        m = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            one_off=True,
+            last_run_at=one_interval_ago,
+            total_run_count=0
+        )
         e = self.Entry(m, app=self.app)
         isdue, delay = e.is_due()
         assert isdue
         assert delay == interval
 
-        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                        one_off=True,
-                                        last_run_at=one_interval_ago,
-                                        total_run_count=1)
+        m2 = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            one_off=True,
+            last_run_at=one_interval_ago,
+            total_run_count=1
+        )
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue
@@ -350,26 +360,32 @@ class test_ModelEntry(SchedulerCase):
         interval = 10
         right_now = self.app.now()
         one_second_later = right_now + timedelta(seconds=1)
-        m = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                       start_time=right_now,
-                                       expires=one_second_later)
+        m = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            start_time=right_now,
+            expires=one_second_later
+        )
         e = self.Entry(m, app=self.app)
         isdue, delay = e.is_due()
         assert isdue
         assert delay == interval
 
-        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                        start_time=right_now,
-                                        expires=right_now)
+        m2 = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            start_time=right_now,
+            expires=right_now
+        )
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue
         assert delay == NEVER_CHECK_TIMEOUT
 
         one_second_ago = right_now - timedelta(seconds=1)
-        m2 = self.create_model_interval(schedule(timedelta(seconds=interval)),
-                                        start_time=right_now,
-                                        expires=one_second_ago)
+        m2 = self.create_model_interval(
+            schedule(timedelta(seconds=interval)),
+            start_time=right_now,
+            expires=one_second_ago
+        )
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue
@@ -714,7 +730,9 @@ class test_DatabaseScheduler(SchedulerCase):
         assert self.s.schedules_equal(self.s.schedule, self.s.schedule)
 
         monkeypatch.setattr(self.s, 'schedule_changed', lambda: True)
-        assert not self.s.schedules_equal(self.s.schedule, self.s.schedule)
+        assert not self.s.schedules_equal(
+            self.s.schedule, self.s.schedule
+        )
 
     def test_heap_always_return_the_first_item(self):
         interval = 10
@@ -893,17 +911,31 @@ class test_DatabaseScheduler(SchedulerCase):
     @pytest.mark.django_db
     def test_crontab_exclusion_logic_basic(self):
         """
-        Test that the crontab exclusion logic properly excludes schedules outside the time window.
+        Test that the crontab exclusion logic properly excludes schedules 
+        outside the time window.
         This is a simple test without timezone complications.
         """
-        # Create crontab schedules with simple hour values in the default timezone
+        # Create crontab schedules with simple hour values in the 
+        # default timezone
         current_hour = datetime.now().hour
-        cron_current_hour = CrontabSchedule.objects.create(hour=str(current_hour))
-        cron_plus_one = CrontabSchedule.objects.create(hour=str((current_hour + 1) % 24))
-        cron_plus_two = CrontabSchedule.objects.create(hour=str((current_hour + 2) % 24))
-        cron_minus_one = CrontabSchedule.objects.create(hour=str((current_hour - 1) % 24))
-        cron_minus_two = CrontabSchedule.objects.create(hour=str((current_hour - 2) % 24))
-        cron_outside = CrontabSchedule.objects.create(hour=str((current_hour + 5) % 24))
+        cron_current_hour = CrontabSchedule.objects.create(
+            hour=str(current_hour)
+        )
+        cron_plus_one = CrontabSchedule.objects.create(
+            hour=str((current_hour + 1) % 24)
+        )
+        cron_plus_two = CrontabSchedule.objects.create(
+            hour=str((current_hour + 2) % 24)
+        )
+        cron_minus_one = CrontabSchedule.objects.create(
+            hour=str((current_hour - 1) % 24)
+        )
+        cron_minus_two = CrontabSchedule.objects.create(
+            hour=str((current_hour - 2) % 24)
+        )
+        cron_outside = CrontabSchedule.objects.create(
+            hour=str((current_hour + 5) % 24)
+        )
 
         # Create a special hour 4 schedule that should always be included
         cron_hour_four = CrontabSchedule.objects.create(hour='4')
@@ -956,7 +988,9 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # Get excluded task IDs
         excluded_tasks = set(
-            PeriodicTask.objects.filter(exclude_query).values_list('id', flat=True)
+            PeriodicTask.objects.filter(exclude_query).values_list(
+                'id', flat=True
+            )
         )
 
         # The test that matters is that hour 4 is always included
@@ -967,7 +1001,8 @@ class test_DatabaseScheduler(SchedulerCase):
                         task_minus_one.id, task_minus_two.id]:
             assert task_id not in excluded_tasks
 
-        # The task outside our time window should be excluded if it's not hour 4
+        # The task outside our time window should be excluded if it's not 
+        # hour 4
         if task_outside.crontab.hour != '4':
             assert task_outside.id in excluded_tasks
 
@@ -989,7 +1024,9 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # Get excluded task IDs
         excluded_tasks = set(
-            PeriodicTask.objects.filter(exclude_query).values_list('id', flat=True)
+            PeriodicTask.objects.filter(exclude_query).values_list(
+                'id', flat=True
+            )
         )
 
         # The hour=4 task should never be excluded
@@ -1000,8 +1037,10 @@ class test_DatabaseScheduler(SchedulerCase):
     @patch('django.utils.timezone.now')
     def test_crontab_timezone_conversion(self, mock_now, mock_get_tz):
         """
-        Test that the scheduler correctly handles crontab schedules with different timezones.
-        This test mocks the server timezone to Tokyo and tests timezone conversions.
+        Test that the scheduler correctly handles crontab schedules with 
+        different timezones.
+        This test mocks the server timezone to Tokyo and tests timezone 
+        conversions.
         """
         # Set up mocks for server timezone and current time
         from datetime import datetime
@@ -1021,14 +1060,23 @@ class test_DatabaseScheduler(SchedulerCase):
         mock_now.return_value = mock_now_dt
         
         # Create tasks with the following crontab schedules:
-        # 1. UTC task at hour 8 - equivalent to 17:00 Tokyo time (current hour) - should be included
-        # 2. New York task at hour 3 - equivalent to 17:00 Tokyo time (current hour) - should be included
-        # 3. UTC task at hour 3 - equivalent to 12:00 Tokyo time - should be excluded (outside window)
+        # 1. UTC task at hour 8 - equivalent to 17:00 Tokyo time (current hour)
+        #    - should be included
+        # 2. New York task at hour 3 - equivalent to 17:00 Tokyo time
+        #    (current hour) - should be included
+        # 3. UTC task at hour 3 - equivalent to 12:00 Tokyo time
+        #    - should be excluded (outside window)
         
         # Create crontab schedules in different timezones
-        utc_current_hour = CrontabSchedule.objects.create(hour='8', timezone='UTC')
-        ny_current_hour = CrontabSchedule.objects.create(hour='3', timezone='America/New_York')
-        utc_outside_window = CrontabSchedule.objects.create(hour='3', timezone='UTC')
+        utc_current_hour = CrontabSchedule.objects.create(
+            hour='8', timezone='UTC'
+        )
+        ny_current_hour = CrontabSchedule.objects.create(
+            hour='3', timezone='America/New_York'
+        )
+        utc_outside_window = CrontabSchedule.objects.create(
+            hour='3', timezone='UTC'
+        )
 
         # Create periodic tasks using these schedules
         task_utc_current = self.create_model(
@@ -1054,15 +1102,23 @@ class test_DatabaseScheduler(SchedulerCase):
 
         # Get excluded task IDs
         excluded_tasks = set(
-            PeriodicTask.objects.filter(exclude_query).values_list('id', flat=True)
+            PeriodicTask.objects.filter(exclude_query).values_list(
+                'id', flat=True
+            )
         )
 
         # Current hour tasks in different timezones should not be excluded
-        assert task_utc_current.id not in excluded_tasks, "UTC current hour task should be included"
-        assert task_ny_current.id not in excluded_tasks, "New York current hour task should be included"
+        assert task_utc_current.id not in excluded_tasks, (
+            "UTC current hour task should be included"
+        )
+        assert task_ny_current.id not in excluded_tasks, (
+            "New York current hour task should be included"
+        )
 
         # Task outside window should be excluded
-        assert task_utc_outside.id in excluded_tasks, "UTC outside window task should be excluded"
+        assert task_utc_outside.id in excluded_tasks, (
+            "UTC outside window task should be excluded"
+        )
 
 
 @pytest.mark.django_db
@@ -1197,18 +1253,21 @@ class test_models(SchedulerCase):
             (nextcheck2 == s2.max_interval) and (isdue2 is False)
 
     def test_ClockedSchedule_schedule(self):
-        due_datetime = make_aware(datetime(day=26,
-                                           month=7,
-                                           year=3000,
-                                           hour=1,
-                                           minute=0))  # future time
+        due_datetime = make_aware(datetime(
+            day=26,
+            month=7,
+            year=3000,
+            hour=1,
+            minute=0
+        ))  # future time
         s = ClockedSchedule(clocked_time=due_datetime)
         dt = datetime(day=25, month=7, year=2050, hour=1, minute=0)
         dt_lastrun = make_aware(dt)
 
         assert s.schedule is not None
         isdue, nextcheck = s.schedule.is_due(dt_lastrun)
-        assert isdue is False  # False means task isn't due, but keep checking.
+        # False means task isn't due, but keep checking.
+        assert isdue is False  
         assert (nextcheck > 0) and (isdue is False) or \
             (nextcheck == s.max_interval) and (isdue is True)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -959,10 +959,6 @@ class test_DatabaseScheduler(SchedulerCase):
             PeriodicTask.objects.filter(exclude_query).values_list('id', flat=True)
         )
 
-        # Print actual results for debugging
-        print(f"Excluded tasks: {excluded_tasks}")
-        print(f"Task outside ID: {task_outside.id}")
-
         # The test that matters is that hour 4 is always included
         assert task_hour_four.id not in excluded_tasks
 
@@ -1055,9 +1051,6 @@ class test_DatabaseScheduler(SchedulerCase):
         excluded_tasks = set(
             PeriodicTask.objects.filter(exclude_query).values_list('id', flat=True)
         )
-
-        # Print actual results for debugging
-        print(f"Excluded tasks: {excluded_tasks}")
 
         # Current hour tasks in different timezones should not be excluded
         assert task_utc_current.id not in excluded_tasks, "UTC current hour task should be included"

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1137,7 +1137,9 @@ class test_DatabaseScheduler(SchedulerCase):
     @pytest.mark.django_db
     @patch('django.utils.timezone.get_current_timezone')
     @patch('django.utils.timezone.now')
-    def test_crontab_timezone_conversion_with_negative_offset_and_dst(self, mock_now, mock_get_tz):
+    def test_crontab_timezone_conversion_with_negative_offset_and_dst(
+        self, mock_now, mock_get_tz
+    ):
         # Set up mocks for server timezone and current time
         from datetime import datetime
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -550,7 +550,7 @@ class test_DatabaseScheduler(SchedulerCase):
     def test_all_as_schedule(self):
         sched = self.s.schedule
         assert sched
-        assert len(sched) == 10
+        assert len(sched) == 9
         assert 'celery.backend_cleanup' in sched
         for n, e in sched.items():
             assert isinstance(e, self.s.Entry)

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -1,0 +1,32 @@
+import datetime
+
+import pytest
+from django.test import override_settings, TestCase
+from django.utils import timezone
+
+from django_celery_beat.utils import aware_now, make_aware
+
+
+@pytest.mark.django_db
+class TestUtils(TestCase):
+    def test_aware_now_with_use_tz_true(self):
+        """Test aware_now when USE_TZ is True"""
+        with override_settings(USE_TZ=True):
+            result = aware_now()
+            assert timezone.is_aware(result)
+            # Convert both timezones to string for comparison
+            assert str(result.tzinfo) == str(timezone.get_current_timezone())
+
+    def test_aware_now_with_use_tz_false(self):
+        """Test aware_now when USE_TZ is False"""
+        with override_settings(USE_TZ=False, TIME_ZONE="Asia/Tokyo"):
+            result = aware_now()
+            assert timezone.is_aware(result)
+            assert result.tzinfo.key == "Asia/Tokyo"
+
+    def test_aware_now_with_use_tz_false_default_timezone(self):
+        """Test aware_now when USE_TZ is False and default TIME_ZONE"""
+        with override_settings(USE_TZ=False):  # Let Django use its default UTC
+            result = aware_now()
+            assert timezone.is_aware(result)
+            assert str(result.tzinfo) == "UTC"

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 from django.test import override_settings, TestCase
 from django.utils import timezone

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from django_celery_beat.utils import aware_now, make_aware
+from django_celery_beat.utils import aware_now
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR enhances the DatabaseScheduler's crontab exclusion logic to properly handle tasks with different timezone settings. The scheduler now correctly converts between timezones when determining which tasks to include in the schedule, making the scheduler more efficient by only loading tasks that might be due soon regardless of their timezone configuration.