### PR TITLE
Periodic task querying is a separate method

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -264,6 +264,22 @@ class DatabaseScheduler(Scheduler):
     def all_as_schedule(self):
         debug('DatabaseScheduler: Fetching database schedule')
         s = {}
+        for model in self.enabled_models():
+            try:
+                s[model.name] = self.Entry(model, app=self.app)
+            except ValueError:
+                pass
+        return s
+
+    def enabled_models(self):
+        """Return list of enabled periodic tasks.
+
+        Allows overriding how the list of periodic tasks is fetched without
+        duplicating the filtering/querying logic.
+        """
+        return list(self.enabled_models_qs())
+
+    def enabled_models_qs(self):
         next_schedule_sync = now() + datetime.timedelta(
             seconds=SCHEDULE_SYNC_MAX_INTERVAL
         )
@@ -278,12 +294,7 @@ class DatabaseScheduler(Scheduler):
         exclude_query = exclude_clock_tasks_query | exclude_cron_tasks_query
 
         # Fetch only the tasks we need to consider
-        for model in self.Model.objects.enabled().exclude(exclude_query):
-            try:
-                s[model.name] = self.Entry(model, app=self.app)
-            except ValueError:
-                pass
-        return s
+        return self.Model.objects.enabled().exclude(exclude_query)
 
     def _get_crontab_exclude_query(self):
         """


### PR DESCRIPTION
Recent changes to how periodic tasks are filtered and fetched broke how [tenant-schemas-celery](https://github.com/maciej-gol/tenant-schemas-celery/issues/152) fetch all periodic tasks from all schemas.

In order not to copy-paste or duck-type new behavior, the filtering logic has been refactored to a separate method, `enabled_models_qs()`. This method does what the original query would do. Next, the queryset is consumed into a list inside `enabled_models()`, which is also used in the old for-loop.

The `enabled_models()` method is a good integration point, as we still have access to the unevaluated queryset there, whilst being able to return simple datastructure which is a list.

In my case, I would use `enabled_models_qs()` to construct the query, and run it against all of the schemas. The result of `enabled_models()` will be the union of all the results across all of the schemas.