### PR TITLE
Consider server timezone on _get_timezone_offset instead of django's settings

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -364,7 +364,9 @@ class DatabaseScheduler(Scheduler):
             int: The hour offset
         """
         # Get server timezone
-        server_tz = timezone.get_current_timezone()
+        # this gets django settings and not server's 
+        # server_tz = timezone.get_current_timezone()
+        server_tz = ZoneInfo(str(server_time.tzinfo))
 
         if isinstance(timezone_name, ZoneInfo):
             timezone_name = timezone_name.key

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -19,7 +19,6 @@ from django.db import close_old_connections, transaction
 from django.db.models import Case, F, IntegerField, Q, When
 from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
-from django.utils import timezone
 from kombu.utils.encoding import safe_repr, safe_str
 from kombu.utils.json import dumps, loads
 
@@ -364,8 +363,6 @@ class DatabaseScheduler(Scheduler):
             int: The hour offset
         """
         # Get server timezone
-        # this gets django settings and not server's 
-        # server_tz = timezone.get_current_timezone()
         server_time = aware_now()
         server_tz = ZoneInfo(str(server_time.tzinfo))
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -366,6 +366,7 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         # this gets django settings and not server's 
         # server_tz = timezone.get_current_timezone()
+        server_time = aware_now()
         server_tz = ZoneInfo(str(server_time.tzinfo))
 
         if isinstance(timezone_name, ZoneInfo):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -272,10 +272,10 @@ class DatabaseScheduler(Scheduler):
             clocked__clocked_time__gt=next_schedule_sync
         )
 
-        # exclude_cron_tasks_query = self._get_crontab_exclude_query()
+        exclude_cron_tasks_query = self._get_crontab_exclude_query()
 
         # Combine the queries for optimal database filtering
-        exclude_query = exclude_clock_tasks_query
+        exclude_query = exclude_clock_tasks_query | exclude_cron_tasks_query
 
         # Fetch only the tasks we need to consider
         for model in self.Model.objects.enabled().exclude(exclude_query):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -272,10 +272,10 @@ class DatabaseScheduler(Scheduler):
             clocked__clocked_time__gt=next_schedule_sync
         )
 
-        exclude_cron_tasks_query = self._get_crontab_exclude_query()
+        # exclude_cron_tasks_query = self._get_crontab_exclude_query()
 
         # Combine the queries for optimal database filtering
-        exclude_query = exclude_clock_tasks_query | exclude_cron_tasks_query
+        exclude_query = exclude_clock_tasks_query
 
         # Fetch only the tasks we need to consider
         for model in self.Model.objects.enabled().exclude(exclude_query):

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -364,7 +364,8 @@ class DatabaseScheduler(Scheduler):
         """
         # Get server timezone
         server_time = aware_now()
-        server_tz = ZoneInfo(str(server_time.tzinfo))
+        # Use server_time.tzinfo directly if it is already a ZoneInfo instance
+        server_tz = server_time.tzinfo if isinstance(server_time.tzinfo, ZoneInfo) else ZoneInfo(str(server_time.tzinfo))
 
         if isinstance(timezone_name, ZoneInfo):
             timezone_name = timezone_name.key


### PR DESCRIPTION
DatabaseScheduler class consider's django timezone calculations to offset hour, but beat uses server's so that creates a situation where some tasks are excluded from running hours

Report: [#885 ](https://github.com/celery/django-celery-beat/issues/885)