### PR TITLE
refactor: tzaware crontab is due method

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -376,9 +376,10 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         server_time = aware_now()
         # Use server_time.tzinfo directly if it is already a ZoneInfo instance
-        server_tz = server_time.tzinfo if isinstance(
-            server_time.tzinfo, ZoneInfo
-        ) else ZoneInfo(str(server_time.tzinfo))
+        if isinstance(server_time.tzinfo, ZoneInfo):
+            server_tz = server_time.tzinfo
+        else:
+            server_tz = ZoneInfo(str(server_time.tzinfo))
 
         if isinstance(timezone_name, ZoneInfo):
             timezone_name = timezone_name.key

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -376,7 +376,9 @@ class DatabaseScheduler(Scheduler):
         # Get server timezone
         server_time = aware_now()
         # Use server_time.tzinfo directly if it is already a ZoneInfo instance
-        server_tz = server_time.tzinfo if isinstance(server_time.tzinfo, ZoneInfo) else ZoneInfo(str(server_time.tzinfo))
+        server_tz = server_time.tzinfo if isinstance(
+            server_time.tzinfo, ZoneInfo
+        ) else ZoneInfo(str(server_time.tzinfo))
 
         if isinstance(timezone_name, ZoneInfo):
             timezone_name = timezone_name.key

--- a/django_celery_beat/tzcrontab.py
+++ b/django_celery_beat/tzcrontab.py
@@ -38,13 +38,7 @@ class TzAwareCrontab(schedules.crontab):
         # convert last_run_at to the schedule timezone
         last_run_at = last_run_at.astimezone(self.tz)
 
-        rem_delta = self.remaining_estimate(last_run_at)
-        rem = max(rem_delta.total_seconds(), 0)
-        due = rem == 0
-        if due:
-            rem_delta = self.remaining_estimate(self.now())
-            rem = max(rem_delta.total_seconds(), 0)
-        return schedstate(due, rem)
+        return super().is_due(last_run_at)
 
     # Needed to support pickling
     def __repr__(self):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1225,8 +1225,8 @@ class test_DatabaseScheduler(SchedulerCase):
         assert task_hour_four.id not in excluded_tasks
 
     @pytest.mark.django_db
-    @patch('django.utils.timezone.get_current_timezone')
     @patch('django_celery_beat.schedulers.aware_now')
+    @patch('django.utils.timezone.get_current_timezone')
     def test_crontab_timezone_conversion(self, mock_get_tz, mock_aware_now):
         # Set up mocks for server timezone and current time
         from datetime import datetime


### PR DESCRIPTION
## Description

This pull request refactors TzAwareCrontab class's is_due() method to adhere to its super class implementation (taking into account the beat_cron_starting_deadline configuration)

## Changes

* Refactored TzAwareCrontab.is_due()
* Added unit tests for the beat_cron_starting_deadline adherence

## Related Issues

#809 