### PR TITLE
refactor: use in operator instead of regex operator in crontab query to fix mssql regression

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -315,13 +315,9 @@ class DatabaseScheduler(Scheduler):
         hours_to_include += [4]  # celery's default cleanup task
 
         # Get all tasks with a simple numeric hour value
-        # Create a list of all valid hour values (0-23).
-        # Both zero-padded ("00"–"09") and non-padded ("0"–"23")
-        valid_hours = [str(hour) for hour in range(24)] + [
-            f"{hour:02d}" for hour in range(10)
-        ]
+        valid_numeric_hours = self._get_valid_hour_formats()
         numeric_hour_tasks = CrontabSchedule.objects.filter(
-            hour__in=valid_hours
+            hour__in=valid_numeric_hours
         )
 
         # Annotate these tasks with their server-hour equivalent
@@ -359,6 +355,15 @@ class DatabaseScheduler(Scheduler):
         )
 
         return exclude_query
+
+    def _get_valid_hour_formats(self):
+        """
+        Return a list of all valid hour values (0-23).
+        Both zero-padded ("00"–"09") and non-padded ("0"–"23")
+        """
+        return [str(hour) for hour in range(24)] + [
+            f"{hour:02d}" for hour in range(10)
+        ]
 
     def _get_unique_timezone_names(self):
         """Get a list of all unique timezone names used in CrontabSchedule"""

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -315,10 +315,8 @@ class DatabaseScheduler(Scheduler):
         hours_to_include += [4]  # celery's default cleanup task
 
         # Get all tasks with a simple numeric hour value
-        # Create a list of all valid hour values (0-23)
-        valid_hours = [str(hour) for hour in range(24)] + [
-            f"{hour:02d}" for hour in range(10)
-        ]
+        # Create a list of all valid hour values (0-23), both padded and non-padded
+        valid_hours = [str(hour) if hour >= 10 else f"{hour:02d}" for hour in range(24)]
         numeric_hour_tasks = CrontabSchedule.objects.filter(
             hour__in=valid_hours
         )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -315,7 +315,11 @@ class DatabaseScheduler(Scheduler):
         hours_to_include += [4]  # celery's default cleanup task
 
         # Get all tasks with a simple numeric hour value
-        # Create a list of all valid hour values (0-23)
+        # Create a list of all valid hour values (0-23).
+        # Both zero-padded ("00"–"09") and non-padded ("0"–"23") formats are included
+        # to account for variations in how hour values are stored in the database.
+        # Some databases or configurations may store single-digit hours without padding,
+        # while others may use zero-padded strings. Including both ensures compatibility.
         # both padded and non-padded
         valid_hours = [str(hour) for hour in range(24)] + [
             f"{hour:02d}" for hour in range(10)

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -316,11 +316,7 @@ class DatabaseScheduler(Scheduler):
 
         # Get all tasks with a simple numeric hour value
         # Create a list of all valid hour values (0-23).
-        # Both zero-padded ("00"–"09") and non-padded ("0"–"23") formats are included
-        # to account for variations in how hour values are stored in the database.
-        # Some databases or configurations may store single-digit hours without padding,
-        # while others may use zero-padded strings. Including both ensures compatibility.
-        # both padded and non-padded
+        # Both zero-padded ("00"–"09") and non-padded ("0"–"23")
         valid_hours = [str(hour) for hour in range(24)] + [
             f"{hour:02d}" for hour in range(10)
         ]

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -315,8 +315,11 @@ class DatabaseScheduler(Scheduler):
         hours_to_include += [4]  # celery's default cleanup task
 
         # Get all tasks with a simple numeric hour value
-        # Create a list of all valid hour values (0-23), both padded and non-padded
-        valid_hours = [str(hour) if hour >= 10 else f"{hour:02d}" for hour in range(24)]
+        # Create a list of all valid hour values (0-23)
+        # both padded and non-padded
+        valid_hours = [str(hour) for hour in range(24)] + [
+            f"{hour:02d}" for hour in range(10)
+        ]
         numeric_hour_tasks = CrontabSchedule.objects.filter(
             hour__in=valid_hours
         )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -314,13 +314,13 @@ class DatabaseScheduler(Scheduler):
         ]
         hours_to_include += [4]  # celery's default cleanup task
 
-        # Regex pattern to match only numbers
-        # This ensures we only process numeric hour values
-        numeric_hour_pattern = r'^\d+$'
-
         # Get all tasks with a simple numeric hour value
+        # Create a list of all valid hour values (0-23)
+        valid_hours = [str(hour) for hour in range(24)] + [
+            f"{hour:02d}" for hour in range(10)
+        ]
         numeric_hour_tasks = CrontabSchedule.objects.filter(
-            hour__regex=numeric_hour_pattern
+            hour__in=valid_hours
         )
 
         # Annotate these tasks with their server-hour equivalent

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1212,6 +1212,40 @@ class test_DatabaseScheduler(SchedulerCase):
             "Paris outside window task should be excluded"
         )
 
+    def test_scheduler_valid_hours(self):
+        """Test the _get_valid_hour_formats method."""
+        # Create an instance of DatabaseScheduler
+        s = self.Scheduler(app=self.app)
+
+        # Get the valid hours list
+        valid_hours = s._get_valid_hour_formats()
+
+        # Basic validations
+        # 24 regular hours + 10 zero-padded hours
+        assert len(valid_hours) == 34
+
+        # Check both regular and zero-padded formats are present
+        assert "0" in valid_hours
+        assert "00" in valid_hours
+        assert "9" in valid_hours
+        assert "09" in valid_hours
+        assert "23" in valid_hours
+
+        # Verify all hours 0-23 are included
+        for hour in range(24):
+            assert str(hour) in valid_hours
+
+        # Verify zero-padded hours 00-09 are included
+        for hour in range(10):
+            assert f"{hour:02d}" in valid_hours
+
+        # Check for duplicates (set should have same length as list)
+        assert len(set(valid_hours)) == len(valid_hours)
+
+        # Verify all entries are valid hour representations
+        for hour_str in valid_hours:
+            hour_value = int(hour_str)
+            assert 0 <= hour_value <= 23
 
 @pytest.mark.django_db
 class test_models(SchedulerCase):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1247,6 +1247,7 @@ class test_DatabaseScheduler(SchedulerCase):
             hour_value = int(hour_str)
             assert 0 <= hour_value <= 23
 
+
 @pytest.mark.django_db
 class test_models(SchedulerCase):
 


### PR DESCRIPTION
## Description

This pull request refactors _get_crontab_exclude_query method of DatabaseScheduler class to use a list of valid numeric hours for crontab query instead of regex pattern

## Related Issues

Fixes: #897  