### PR TITLE
replace % with mod() SQL function to avoid invalid double-percentage …

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -16,7 +16,8 @@ from celery.utils.time import maybe_make_aware
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import close_old_connections, transaction
-from django.db.models import Case, ExpressionWrapper, F, Func, IntegerField, Q, When
+from django.db.models import (Case, ExpressionWrapper, F, Func, IntegerField,
+                              Q, When)
 from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
 from kombu.utils.encoding import safe_repr, safe_str

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -16,8 +16,9 @@ from celery.utils.time import maybe_make_aware
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import close_old_connections, transaction
-from django.db.models import (Case, ExpressionWrapper, F, Func, IntegerField,
-                              Q, When)
+from django.db.models import (
+    Case, ExpressionWrapper, F, Func, IntegerField, Q, When
+)
 from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
 from kombu.utils.encoding import safe_repr, safe_str

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -16,9 +16,8 @@ from celery.utils.time import maybe_make_aware
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import close_old_connections, transaction
-from django.db.models import (
-    Case, ExpressionWrapper, F, Func, IntegerField, Q, When
-)
+from django.db.models import (Case, ExpressionWrapper, F, Func, IntegerField,
+                              Q, When)
 from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
 from kombu.utils.encoding import safe_repr, safe_str


### PR DESCRIPTION
fixes https://github.com/celery/django-celery-beat/issues/922

invalid SQL before:
```sql
SELECT
	`django_celery_beat_periodictask`.`id`,
	`django_celery_beat_periodictask`.`name`,
	`django_celery_beat_periodictask`.`task`,
	`django_celery_beat_periodictask`.`interval_id`,
	`django_celery_beat_periodictask`.`crontab_id`,
	`django_celery_beat_periodictask`.`solar_id`,
	`django_celery_beat_periodictask`.`clocked_id`,
	`django_celery_beat_periodictask`.`args`,
	`django_celery_beat_periodictask`.`kwargs`,
	`django_celery_beat_periodictask`.`queue`,
	`django_celery_beat_periodictask`.`exchange`,
	`django_celery_beat_periodictask`.`routing_key`,
	`django_celery_beat_periodictask`.`headers`,
	`django_celery_beat_periodictask`.`priority`,
	`django_celery_beat_periodictask`.`expires`,
	`django_celery_beat_periodictask`.`expire_seconds`,
	`django_celery_beat_periodictask`.`one_off`,
	`django_celery_beat_periodictask`.`start_time`,
	`django_celery_beat_periodictask`.`enabled`,
	`django_celery_beat_periodictask`.`last_run_at`,
	`django_celery_beat_periodictask`.`total_run_count`,
	`django_celery_beat_periodictask`.`date_changed`,
	`django_celery_beat_periodictask`.`description`
FROM
	`django_celery_beat_periodictask`
LEFT OUTER JOIN `django_celery_beat_clockedschedule` ON
	(`django_celery_beat_periodictask`.`clocked_id` = `django_celery_beat_clockedschedule`.`id`)
WHERE
	(`django_celery_beat_periodictask`.`enabled` = 1
		AND NOT (((`django_celery_beat_clockedschedule`.`clocked_time` > '2025-07-29 14:05:32.092804'
			AND `django_celery_beat_clockedschedule`.`clocked_time` IS NOT NULL
			AND `django_celery_beat_periodictask`.`clocked_id` IS NOT NULL)
		OR (`django_celery_beat_periodictask`.`crontab_id` IS NOT NULL
			AND `django_celery_beat_periodictask`.`crontab_id` IN (
			SELECT
				U0.`id` AS `id`
			FROM
				`django_celery_beat_crontabschedule` U0
			WHERE
				(U0.`hour` REGEXP BINARY '^\\d+$'
					AND NOT (CASE
						WHEN (U0.`timezone` = 'UTC') THEN (((CAST(U0.`hour` AS signed integer) + 0) + 24) %% 24)
						ELSE CAST(U0.`hour` AS signed integer)
					END IN (12, 13, 14, 15, 16, 4))))
				AND `django_celery_beat_periodictask`.`crontab_id` IS NOT NULL))))
```

new SQL:
```sql
SELECT
	`django_celery_beat_periodictask`.`id`,
	`django_celery_beat_periodictask`.`name`,
	`django_celery_beat_periodictask`.`task`,
	`django_celery_beat_periodictask`.`interval_id`,
	`django_celery_beat_periodictask`.`crontab_id`,
	`django_celery_beat_periodictask`.`solar_id`,
	`django_celery_beat_periodictask`.`clocked_id`,
	`django_celery_beat_periodictask`.`args`,
	`django_celery_beat_periodictask`.`kwargs`,
	`django_celery_beat_periodictask`.`queue`,
	`django_celery_beat_periodictask`.`exchange`,
	`django_celery_beat_periodictask`.`routing_key`,
	`django_celery_beat_periodictask`.`headers`,
	`django_celery_beat_periodictask`.`priority`,
	`django_celery_beat_periodictask`.`expires`,
	`django_celery_beat_periodictask`.`expire_seconds`,
	`django_celery_beat_periodictask`.`one_off`,
	`django_celery_beat_periodictask`.`start_time`,
	`django_celery_beat_periodictask`.`enabled`,
	`django_celery_beat_periodictask`.`last_run_at`,
	`django_celery_beat_periodictask`.`total_run_count`,
	`django_celery_beat_periodictask`.`date_changed`,
	`django_celery_beat_periodictask`.`description`
FROM
	`django_celery_beat_periodictask`
LEFT OUTER JOIN `django_celery_beat_clockedschedule` ON
	(`django_celery_beat_periodictask`.`clocked_id` = `django_celery_beat_clockedschedule`.`id`)
WHERE
	(`django_celery_beat_periodictask`.`enabled` = 1
		AND NOT (((`django_celery_beat_clockedschedule`.`clocked_time` > '2025-07-29 10:42:42.813538'
			AND `django_celery_beat_clockedschedule`.`clocked_time` IS NOT NULL
			AND `django_celery_beat_periodictask`.`clocked_id` IS NOT NULL)
		OR (`django_celery_beat_periodictask`.`crontab_id` IS NOT NULL
			AND `django_celery_beat_periodictask`.`crontab_id` IN (
			SELECT
				U0.`id` AS `id`
			FROM
				`django_celery_beat_crontabschedule` U0
			WHERE
				(U0.`hour` REGEXP BINARY '^\\d+$'
					AND NOT (CASE
						WHEN (U0.`timezone` = 'UTC') THEN MOD(((CAST(U0.`hour` AS signed integer) + 0) + 24), 24)
						ELSE CAST(U0.`hour` AS signed integer)
					END IN (12, 13, 14, 15, 16, 4))))
				AND `django_celery_beat_periodictask`.`crontab_id` IS NOT NULL))))
```