### PR TITLE
GitHub Actions: Test on Python 3.14 release candidate 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix: # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
         django-version: ["3.2", "4.2", "5.1", "5.2"]
-        python-version: ['3.8','3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
         exclude:
           - django-version: "3.2"
             python-version: "3.11"
@@ -31,6 +31,9 @@ jobs:
             python-version: "3.8"
           - django-version: "5.2"
             python-version: "3.8"
+        include: 
+          - django-version: "5.2"
+            python-version: "3.14"
 
     services:
       rabbitmq:
@@ -44,6 +47,7 @@ jobs:
       uses: useblacksmith/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
     pypy-3.10: pypy3
 
 [gh-actions:env]
@@ -25,6 +26,7 @@ envlist =
     py311-django{42,51,52}
     py312-django{42,51,52}
     py313-django{52}
+    py314-django{52}
     pypy3-django{32,42,51,52}
     flake8
     apicheck


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc2