### PR TITLE
Dry-run Database Scheduler

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -542,3 +542,25 @@ class DatabaseScheduler(Scheduler):
                     repr(entry) for entry in self._schedule.values()),
                 )
         return self._schedule
+
+
+class DryRunDatabaseScheduler(DatabaseScheduler):
+    """
+    DatabaseScheduler in dry-run mode.
+
+    The Scheduler reads Periodic Tasks from the database but does not execute them,
+    only logging when they would have been triggered.
+    Useful in environments where tasks should not actually run, but the scheduler
+    must remain operational.
+    """
+
+    def apply_entry(self, entry, producer=None):
+        """
+        Overwritten method to log the triggered tasks instead of actually running it.
+        """
+        debug(
+            'Dry-run mode: Skipping task %s %s %s',
+            entry.task,
+            entry.args,
+            entry.kwargs
+        )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -556,7 +556,7 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
 
     def apply_entry(self, entry, producer=None):
         """
-        Overwritten method to log the triggered tasks instead of actually running it.
+        Overwritten method to log the triggered tasks instead of actually running them.
         """
         debug(
             'Dry-run mode: Skipping task %s %s %s',

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -564,3 +564,17 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
             entry.args,
             entry.kwargs
         )
+
+    def sync(self):
+        """
+        Override sync to avoid persisting execution metadata in dry-run mode.
+
+        In DatabaseScheduler, sync() saves dirty entries (including updated
+        last_run_at and total_run_count) back to the database. For a dry-run
+        scheduler this would be misleading, since tasks are never actually run.
+
+        By overriding sync as a no-op, we ensure that dry-run operation does not
+        modify PeriodicTask records in the database while still allowing the
+        scheduler machinery to operate normally.
+        """
+        debug('Dry-run mode: Skipping database sync of scheduled tasks.')

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -593,11 +593,12 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
     """
 
     def apply_entry(self, entry, producer=None):
-        """Log the triggered task and advance runtime state without executing.
+        """Log the triggered task without executing.
 
-        Calls reserve() to update last_run_at and total_run_count in memory
-        and mark the entry as dirty. This ensures _refresh_schedule() preserves
-        the runtime state across periodic schedule reloads from the database.
+        This method is called by tick() after reserve() has already advanced
+        last_run_at and total_run_count in memory and marked the entry as
+        dirty. This ensures _refresh_schedule() preserves the runtime state
+        across periodic schedule reloads from the database.
         """
         info(
             'Dry-run mode: Task %s would have been sent. args=%s kwargs=%s',
@@ -605,7 +606,6 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
             entry.args,
             entry.kwargs,
         )
-        self.reserve(entry)
 
     def sync(self):
         """Skip persisting execution metadata to the database.

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -589,7 +589,7 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
 
     def apply_entry(self, entry, producer=None):
         """
-        Overwritten method to log the triggered tasks instead of actually running it.
+        Overwritten method to log the triggered tasks instead of actually running them.
         """
         debug(
             'Dry-run mode: Skipping task %s %s %s',

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -593,12 +593,13 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
     """
 
     def apply_entry(self, entry, producer=None):
-        """Log the triggered task without executing.
+        """Log the triggered task instead of executing it.
 
-        This method is called by tick() after reserve() has already advanced
-        last_run_at and total_run_count in memory and marked the entry as
-        dirty. This ensures _refresh_schedule() preserves the runtime state
-        across periodic schedule reloads from the database.
+        In dry-run mode the task is never dispatched (apply_async is not
+        called). By the time tick() calls this method, reserve() has already
+        advanced last_run_at/total_run_count in memory and marked the entry as
+        dirty; that (not this method) is what allows _refresh_schedule() to
+        preserve runtime state across schedule reloads.
         """
         info(
             'Dry-run mode: Task %s would have been sent. args=%s kwargs=%s',

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -597,3 +597,17 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
             entry.args,
             entry.kwargs
         )
+
+    def sync(self):
+        """
+        Override sync to avoid persisting execution metadata in dry-run mode.
+
+        In DatabaseScheduler, sync() saves dirty entries (including updated
+        last_run_at and total_run_count) back to the database. For a dry-run
+        scheduler this would be misleading, since tasks are never actually run.
+
+        By overriding sync as a no-op, we ensure that dry-run operation does not
+        modify PeriodicTask records in the database while still allowing the
+        scheduler machinery to operate normally.
+        """
+        debug('Dry-run mode: Skipping database sync of scheduled tasks.')

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -575,3 +575,25 @@ class DatabaseScheduler(Scheduler):
                     repr(entry) for entry in self._schedule.values()),
                 )
         return self._schedule
+
+
+class DryRunDatabaseScheduler(DatabaseScheduler):
+    """
+    DatabaseScheduler in dry-run mode.
+
+    The Scheduler reads Periodic Tasks from the database but does not execute them,
+    only logging when they would have been triggered.
+    Useful in environments where tasks should not actually run, but the scheduler
+    must remain operational.
+    """
+
+    def apply_entry(self, entry, producer=None):
+        """
+        Overwritten method to log the triggered tasks instead of actually running it.
+        """
+        debug(
+            'Dry-run mode: Skipping task %s %s %s',
+            entry.task,
+            entry.args,
+            entry.kwargs
+        )

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -581,33 +581,42 @@ class DryRunDatabaseScheduler(DatabaseScheduler):
     """
     DatabaseScheduler in dry-run mode.
 
-    The Scheduler reads Periodic Tasks from the database but does not execute them,
-    only logging when they would have been triggered.
-    Useful in environments where tasks should not actually run, but the scheduler
-    must remain operational.
+    The Scheduler reads Periodic Tasks from the database but does not execute
+    them, only logging when they would have been triggered.
+
+    Useful in environments where tasks should not actually run, but the
+    scheduler must remain operational (e.g. development/staging).
+
+    Runtime state (last_run_at, total_run_count) is maintained in memory via
+    reserve() so that tasks are not re-triggered on schedule refreshes, but
+    is never persisted to the database.
     """
 
     def apply_entry(self, entry, producer=None):
+        """Log the triggered task and advance runtime state without executing.
+
+        Calls reserve() to update last_run_at and total_run_count in memory
+        and mark the entry as dirty. This ensures _refresh_schedule() preserves
+        the runtime state across periodic schedule reloads from the database.
         """
-        Overwritten method to log the triggered tasks instead of actually running them.
-        """
-        debug(
-            'Dry-run mode: Skipping task %s %s %s',
-            entry.task,
+        info(
+            'Dry-run mode: Task %s would have been sent. args=%s kwargs=%s',
+            entry.name,
             entry.args,
-            entry.kwargs
+            entry.kwargs,
         )
+        self.reserve(entry)
 
     def sync(self):
-        """
-        Override sync to avoid persisting execution metadata in dry-run mode.
+        """Skip persisting execution metadata to the database.
 
         In DatabaseScheduler, sync() saves dirty entries (including updated
-        last_run_at and total_run_count) back to the database. For a dry-run
-        scheduler this would be misleading, since tasks are never actually run.
+        last_run_at and total_run_count) back to the database. In dry-run mode,
+        tasks are never actually executed, so writing this metadata would be
+        misleading.
 
-        By overriding sync as a no-op, we ensure that dry-run operation does not
-        modify PeriodicTask records in the database while still allowing the
-        scheduler machinery to operate normally.
+        The _dirty set is intentionally left uncleared so that
+        _refresh_schedule() continues to preserve in-memory runtime state
+        when the schedule is reloaded from the database.
         """
         debug('Dry-run mode: Skipping database sync of scheduled tasks.')

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -229,6 +229,46 @@ with only one command (recommended for **development environment only**):
 
 
 
+Dry-run mode (DryRunDatabaseScheduler)
+---------------------------------------
+
+The ``DryRunDatabaseScheduler`` reads periodic tasks from the database exactly
+like the standard ``DatabaseScheduler``, but never actually executes them.
+Instead it logs a message each time a task *would* have been sent.
+
+This is useful in development or staging environments where you want to verify
+that your schedule configuration is correct and tasks are triggering at the
+expected times, without producing side-effects.
+
+To use it, specify the dry-run scheduler when starting beat:
+
+.. code-block:: sh
+
+   $ celery -A [project-name] beat -l info --scheduler django_celery_beat.schedulers:DryRunDatabaseScheduler
+
+Or via Django settings:
+
+.. code-block:: python
+
+   CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DryRunDatabaseScheduler'
+
+When a task becomes due you will see a log line like::
+
+   [INFO] Dry-run mode: Task my-periodic-task would have been sent. args=[1, 2] kwargs={'key': 'value'}
+
+Key behaviours:
+
+- **No task execution**: ``apply_async`` is never called; workers will not
+  receive any messages from this scheduler.
+- **No database writes**: execution metadata (``last_run_at``,
+  ``total_run_count``) is maintained in memory but never persisted to the
+  database, so switching back to the standard scheduler resumes from where
+  it last actually ran.
+- **Correct scheduling**: the scheduler still tracks ``last_run_at`` in memory
+  so that tasks are not re-triggered incorrectly within the same process
+  lifetime, even across periodic schedule refreshes from the database.
+
+
 Working with django-celery-results
 -----------------------------------
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -56,6 +56,18 @@ class EntrySaveRaises(schedulers.ModelEntry):
         raise RuntimeError('this is expected')
 
 
+class DryRunTrackingScheduler(schedulers.DryRunDatabaseScheduler):
+    Entry = EntryTrackSave
+
+    def __init__(self, *args, **kwargs):
+        self.flushed = 0
+        schedulers.DryRunDatabaseScheduler.__init__(self, *args, **kwargs)
+
+    def sync(self):
+        self.flushed += 1
+        schedulers.DryRunDatabaseScheduler.sync(self)
+
+
 class TrackingScheduler(schedulers.DatabaseScheduler):
     Entry = EntryTrackSave
 
@@ -66,7 +78,6 @@ class TrackingScheduler(schedulers.DatabaseScheduler):
     def sync(self):
         self.flushed += 1
         schedulers.DatabaseScheduler.sync(self)
-
 
 @pytest.mark.django_db
 class SchedulerCase:
@@ -1406,6 +1417,56 @@ class test_DatabaseScheduler(SchedulerCase):
         for hour_str in valid_hours:
             hour_value = int(hour_str)
             assert 0 <= hour_value <= 23
+
+@pytest.mark.django_db
+class test_DryRunDatabaseScheduler(SchedulerCase):
+    Scheduler = DryRunTrackingScheduler
+
+    @pytest.fixture(autouse=True)
+    def setup_scheduler(self, app):
+        self.app = app
+        self.app.conf.beat_schedule = {}
+
+        self.m1 = self.create_model_interval(
+            schedule(timedelta(seconds=10)),
+            last_run_at=self.app.now() - timedelta(days=1),
+        )
+        self.m1.save()
+        self.m1.refresh_from_db()
+
+        self.s = self.Scheduler(app=self.app)
+
+    def test_apply_entry_logs_without_dispatching(self):
+        entry = self.s.schedule[self.m1.name]
+        self.s.apply_async = MagicMock()
+
+        with patch('django_celery_beat.schedulers.debug') as mock_debug:
+            self.s.apply_entry(entry)
+
+        self.s.apply_async.assert_not_called()
+        mock_debug.assert_called_once_with(
+            'Dry-run mode: Skipping task %s %s %s',
+            entry.task,
+            entry.args,
+            entry.kwargs,
+        )
+
+    def test_sync_does_not_persist_run_metadata(self):
+        entry = self.s.schedule[self.m1.name]
+        initial_flushes = self.s.flushed
+        original_last_run_at = entry.model.last_run_at
+        original_total_run_count = entry.model.total_run_count
+
+        entry.model.last_run_at = entry.last_run_at + timedelta(hours=1)
+        entry.model.total_run_count += 1
+        self.s._dirty.add(entry.name)
+
+        self.s.sync()
+        self.m1.refresh_from_db()
+
+        assert self.s.flushed == initial_flushes + 1
+        assert self.m1.last_run_at == original_last_run_at
+        assert self.m1.total_run_count == original_total_run_count
 
 
 @pytest.mark.django_db

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -79,6 +79,7 @@ class TrackingScheduler(schedulers.DatabaseScheduler):
         self.flushed += 1
         schedulers.DatabaseScheduler.sync(self)
 
+
 @pytest.mark.django_db
 class SchedulerCase:
 
@@ -1417,6 +1418,7 @@ class test_DatabaseScheduler(SchedulerCase):
         for hour_str in valid_hours:
             hour_value = int(hour_str)
             assert 0 <= hour_value <= 23
+
 
 @pytest.mark.django_db
 class test_DryRunDatabaseScheduler(SchedulerCase):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1432,7 +1432,6 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
             last_run_at=self.app.now() - timedelta(days=1),
         )
         self.m1.save()
-        self.m1.refresh_from_db()
 
         self.s = self.Scheduler(app=self.app)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -58,6 +58,18 @@ class EntrySaveRaises(schedulers.ModelEntry):
         raise RuntimeError('this is expected')
 
 
+class DryRunTrackingScheduler(schedulers.DryRunDatabaseScheduler):
+    Entry = EntryTrackSave
+
+    def __init__(self, *args, **kwargs):
+        self.flushed = 0
+        schedulers.DryRunDatabaseScheduler.__init__(self, *args, **kwargs)
+
+    def sync(self):
+        self.flushed += 1
+        schedulers.DryRunDatabaseScheduler.sync(self)
+
+
 class TrackingScheduler(schedulers.DatabaseScheduler):
     Entry = EntryTrackSave
 
@@ -68,7 +80,6 @@ class TrackingScheduler(schedulers.DatabaseScheduler):
     def sync(self):
         self.flushed += 1
         schedulers.DatabaseScheduler.sync(self)
-
 
 @pytest.mark.django_db
 class SchedulerCase:
@@ -1555,6 +1566,56 @@ class test_DatabaseScheduler(SchedulerCase):
         for hour_str in valid_hours:
             hour_value = int(hour_str)
             assert 0 <= hour_value <= 23
+
+@pytest.mark.django_db
+class test_DryRunDatabaseScheduler(SchedulerCase):
+    Scheduler = DryRunTrackingScheduler
+
+    @pytest.fixture(autouse=True)
+    def setup_scheduler(self, app):
+        self.app = app
+        self.app.conf.beat_schedule = {}
+
+        self.m1 = self.create_model_interval(
+            schedule(timedelta(seconds=10)),
+            last_run_at=self.app.now() - timedelta(days=1),
+        )
+        self.m1.save()
+        self.m1.refresh_from_db()
+
+        self.s = self.Scheduler(app=self.app)
+
+    def test_apply_entry_logs_without_dispatching(self):
+        entry = self.s.schedule[self.m1.name]
+        self.s.apply_async = MagicMock()
+
+        with patch('django_celery_beat.schedulers.debug') as mock_debug:
+            self.s.apply_entry(entry)
+
+        self.s.apply_async.assert_not_called()
+        mock_debug.assert_called_once_with(
+            'Dry-run mode: Skipping task %s %s %s',
+            entry.task,
+            entry.args,
+            entry.kwargs,
+        )
+
+    def test_sync_does_not_persist_run_metadata(self):
+        entry = self.s.schedule[self.m1.name]
+        initial_flushes = self.s.flushed
+        original_last_run_at = entry.model.last_run_at
+        original_total_run_count = entry.model.total_run_count
+
+        entry.model.last_run_at = entry.last_run_at + timedelta(hours=1)
+        entry.model.total_run_count += 1
+        self.s._dirty.add(entry.name)
+
+        self.s.sync()
+        self.m1.refresh_from_db()
+
+        assert self.s.flushed == initial_flushes + 1
+        assert self.m1.last_run_at == original_last_run_at
+        assert self.m1.total_run_count == original_total_run_count
 
 
 @pytest.mark.django_db

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1581,7 +1581,6 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
             last_run_at=self.app.now() - timedelta(days=1),
         )
         self.m1.save()
-        self.m1.refresh_from_db()
 
         self.s = self.Scheduler(app=self.app)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -81,6 +81,7 @@ class TrackingScheduler(schedulers.DatabaseScheduler):
         self.flushed += 1
         schedulers.DatabaseScheduler.sync(self)
 
+
 @pytest.mark.django_db
 class SchedulerCase:
 
@@ -1566,6 +1567,7 @@ class test_DatabaseScheduler(SchedulerCase):
         for hour_str in valid_hours:
             hour_value = int(hour_str)
             assert 0 <= hour_value <= 23
+
 
 @pytest.mark.django_db
 class test_DryRunDatabaseScheduler(SchedulerCase):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1607,20 +1607,30 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
 
         self.s.apply_async.assert_not_called()
 
+    def _simulate_tick(self, entry):
+        """Mirror what Scheduler.tick() does for a due entry.
+
+        tick() reserves the entry (advancing run metadata in memory and
+        returning the next entry), then calls apply_entry() with the original
+        entry. Returns the reserved (next) entry, matching tick()'s local var.
+        """
+        next_entry = self.s.reserve(entry)
+        self.s.apply_entry(entry)
+        return next_entry
+
     def test_tick_cycle_advances_run_metadata_in_memory(self):
         # tick() calls reserve() (which advances state) then apply_entry().
         # This test simulates that cycle and verifies the in-memory run
         # metadata is advanced and the entry is marked dirty.
         entry = self.s.schedule[self.m1.name]
-        original_last_run_at = entry.last_run_at
+        original_last_run_at = entry.model.last_run_at
         original_total_run_count = entry.model.total_run_count
 
-        new_entry = self.s.reserve(entry)
-        self.s.apply_entry(entry)
+        next_entry = self._simulate_tick(entry)
 
         # reserve() should have advanced last_run_at and total_run_count
-        assert new_entry.model.last_run_at > original_last_run_at
-        assert new_entry.model.total_run_count == (
+        assert next_entry.model.last_run_at > original_last_run_at
+        assert next_entry.model.total_run_count == (
             original_total_run_count + 1
         )
         # Entry should be marked dirty
@@ -1632,9 +1642,7 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         original_last_run_at = entry.model.last_run_at
         original_total_run_count = entry.model.total_run_count
 
-        # Simulate a full tick: reserve (advances state) + apply_entry (logs)
-        self.s.reserve(entry)
-        self.s.apply_entry(entry)
+        self._simulate_tick(entry)
         self.s.sync()
         self.m1.refresh_from_db()
 
@@ -1653,10 +1661,8 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         """
         entry = self.s.schedule[self.m1.name]
 
-        # Simulate a full tick: reserve (advances state) + apply_entry (logs)
-        new_entry = self.s.reserve(entry)
-        self.s.apply_entry(entry)
-        last_run_after_apply = new_entry.model.last_run_at
+        next_entry = self._simulate_tick(entry)
+        last_run_after_apply = next_entry.model.last_run_at
 
         # Force a full schedule refresh by backdating _last_full_sync
         self.s._last_full_sync = (

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1658,7 +1658,9 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
 
         # Force a full schedule refresh by backdating _last_full_sync
         self.s._last_full_sync = (
-            datetime.now() - timedelta(seconds=301)
+            datetime.now() - timedelta(
+                seconds=schedulers.SCHEDULE_SYNC_MAX_INTERVAL + 1
+            )
         )
         # Access .schedule to trigger the refresh
         refreshed_schedule = self.s.schedule
@@ -1679,7 +1681,9 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
 
         # Force a full schedule refresh
         self.s._last_full_sync = (
-            datetime.now() - timedelta(seconds=301)
+            datetime.now() - timedelta(
+                seconds=schedulers.SCHEDULE_SYNC_MAX_INTERVAL + 1
+            )
         )
         refreshed_schedule = self.s.schedule
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1588,18 +1588,40 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
 
     def test_apply_entry_logs_without_dispatching(self):
         entry = self.s.schedule[self.m1.name]
-        self.s.apply_async = MagicMock()
 
-        with patch('django_celery_beat.schedulers.debug') as mock_debug:
+        with patch('django_celery_beat.schedulers.info') as mock_info:
             self.s.apply_entry(entry)
 
-        self.s.apply_async.assert_not_called()
-        mock_debug.assert_called_once_with(
-            'Dry-run mode: Skipping task %s %s %s',
-            entry.task,
+        mock_info.assert_called_once_with(
+            'Dry-run mode: Task %s would have been sent. args=%s kwargs=%s',
+            entry.name,
             entry.args,
             entry.kwargs,
         )
+
+    def test_apply_entry_does_not_send_task(self):
+        entry = self.s.schedule[self.m1.name]
+        self.s.apply_async = MagicMock()
+
+        self.s.apply_entry(entry)
+
+        self.s.apply_async.assert_not_called()
+
+    def test_apply_entry_calls_reserve(self):
+        entry = self.s.schedule[self.m1.name]
+        original_last_run_at = entry.last_run_at
+        original_total_run_count = entry.model.total_run_count
+
+        self.s.apply_entry(entry)
+
+        # reserve() should have advanced last_run_at and total_run_count
+        updated_entry = self.s.schedule[self.m1.name]
+        assert updated_entry.model.last_run_at > original_last_run_at
+        assert updated_entry.model.total_run_count == (
+            original_total_run_count + 1
+        )
+        # Entry should be marked dirty
+        assert self.m1.name in self.s._dirty
 
     def test_sync_does_not_persist_run_metadata(self):
         entry = self.s.schedule[self.m1.name]
@@ -1607,16 +1629,59 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         original_last_run_at = entry.model.last_run_at
         original_total_run_count = entry.model.total_run_count
 
-        entry.model.last_run_at = entry.last_run_at + timedelta(hours=1)
-        entry.model.total_run_count += 1
-        self.s._dirty.add(entry.name)
-
+        # Simulate a task being triggered (updates in-memory state)
+        self.s.apply_entry(entry)
         self.s.sync()
         self.m1.refresh_from_db()
 
         assert self.s.flushed == initial_flushes + 1
+        # Database should still have the original values
         assert self.m1.last_run_at == original_last_run_at
         assert self.m1.total_run_count == original_total_run_count
+
+    def test_schedule_refresh_preserves_last_run_at(self):
+        """Regression test: schedule refresh must not reset last_run_at.
+
+        When the schedule property triggers a full reload from the DB
+        (e.g. every SCHEDULE_SYNC_MAX_INTERVAL), tasks that were "run" in
+        dry-run mode must retain their in-memory last_run_at so they don't
+        become due again immediately.
+        """
+        entry = self.s.schedule[self.m1.name]
+
+        # Simulate the task being triggered in dry-run mode
+        self.s.apply_entry(entry)
+        updated_entry = self.s.schedule[self.m1.name]
+        last_run_after_apply = updated_entry.model.last_run_at
+
+        # Force a full schedule refresh by backdating _last_full_sync
+        self.s._last_full_sync = (
+            datetime.now() - timedelta(seconds=301)
+        )
+        # Access .schedule to trigger the refresh
+        refreshed_schedule = self.s.schedule
+
+        # last_run_at should be preserved from in-memory state, not reset
+        # to the stale DB value
+        refreshed_entry = refreshed_schedule[self.m1.name]
+        assert refreshed_entry.model.last_run_at == last_run_after_apply
+
+    def test_schedule_refresh_picks_up_new_tasks(self):
+        """New tasks added to the DB should appear after a schedule refresh."""
+        m2 = self.create_model_interval(
+            schedule(timedelta(seconds=30)),
+            last_run_at=self.app.now() - timedelta(hours=1),
+        )
+        m2.save()
+        PeriodicTasks.update_changed()
+
+        # Force a full schedule refresh
+        self.s._last_full_sync = (
+            datetime.now() - timedelta(seconds=301)
+        )
+        refreshed_schedule = self.s.schedule
+
+        assert m2.name in refreshed_schedule
 
 
 @pytest.mark.django_db

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1607,12 +1607,14 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
 
         self.s.apply_async.assert_not_called()
 
-    def test_apply_entry_calls_reserve(self):
+    def test_tick_cycle_advances_run_metadata_in_memory(self):
+        # tick() calls reserve() (which advances state) then apply_entry().
+        # This test simulates that cycle and verifies the in-memory run
+        # metadata is advanced and the entry is marked dirty.
         entry = self.s.schedule[self.m1.name]
         original_last_run_at = entry.last_run_at
         original_total_run_count = entry.model.total_run_count
 
-        # Simulate what tick() does: reserve then apply_entry
         new_entry = self.s.reserve(entry)
         self.s.apply_entry(entry)
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1612,12 +1612,13 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         original_last_run_at = entry.last_run_at
         original_total_run_count = entry.model.total_run_count
 
+        # Simulate what tick() does: reserve then apply_entry
+        new_entry = self.s.reserve(entry)
         self.s.apply_entry(entry)
 
         # reserve() should have advanced last_run_at and total_run_count
-        updated_entry = self.s.schedule[self.m1.name]
-        assert updated_entry.model.last_run_at > original_last_run_at
-        assert updated_entry.model.total_run_count == (
+        assert new_entry.model.last_run_at > original_last_run_at
+        assert new_entry.model.total_run_count == (
             original_total_run_count + 1
         )
         # Entry should be marked dirty
@@ -1629,7 +1630,8 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         original_last_run_at = entry.model.last_run_at
         original_total_run_count = entry.model.total_run_count
 
-        # Simulate a task being triggered (updates in-memory state)
+        # Simulate a full tick: reserve (advances state) + apply_entry (logs)
+        self.s.reserve(entry)
         self.s.apply_entry(entry)
         self.s.sync()
         self.m1.refresh_from_db()
@@ -1649,10 +1651,10 @@ class test_DryRunDatabaseScheduler(SchedulerCase):
         """
         entry = self.s.schedule[self.m1.name]
 
-        # Simulate the task being triggered in dry-run mode
+        # Simulate a full tick: reserve (advances state) + apply_entry (logs)
+        new_entry = self.s.reserve(entry)
         self.s.apply_entry(entry)
-        updated_entry = self.s.schedule[self.m1.name]
-        last_run_after_apply = updated_entry.model.last_run_at
+        last_run_after_apply = new_entry.model.last_run_at
 
         # Force a full schedule refresh by backdating _last_full_sync
         self.s._last_full_sync = (


### PR DESCRIPTION
Description
-----------

Introduces the `DryRunDatabaseScheduler` to read Periodic Tasks from the
database while operating in dry-run mode.

The dry-run mode is useful for setting up projects with Periodic Tasks stored
in the Django database while skipping their execution in non-production
environments, such as local or staging setups.

The Scheduler class inherits from `DatabaseScheduler` and:

- Overrides `apply_entry` to log the triggered tasks instead of dispatching
  them (`apply_async` is never called).
- Overrides `sync` as a no-op so execution metadata (`last_run_at`,
  `total_run_count`) is never persisted to the database. Switching back to the
  standard scheduler therefore resumes from where tasks last actually ran.
- Preserves run metadata in memory across periodic schedule refreshes (relying
  on `_dirty` + `_refresh_schedule`), so tasks are not incorrectly re-triggered
  during the process lifetime.

Also adds unit test coverage for the dry-run behaviour and documentation with
usage examples in `docs/includes/introduction.txt`.

---

Fixes: #942
* #942
