### PR TITLE
fix: Accept expires as alias for expire_seconds

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -215,8 +215,8 @@ class ModelEntry(ScheduleEntry):
     def _unpack_options(cls, queue=None, exchange=None, routing_key=None,
                         priority=None, headers=None, expire_seconds=None,
                         expires=None, **kwargs):
-        if expire_seconds is None and isinstance(expires, (int, float)):
-            expire_seconds = int(expires)
+        if expire_seconds is None and expires is not None:
+            expire_seconds = expires
         return {
             'queue': queue,
             'exchange': exchange,

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -214,7 +214,9 @@ class ModelEntry(ScheduleEntry):
     @classmethod
     def _unpack_options(cls, queue=None, exchange=None, routing_key=None,
                         priority=None, headers=None, expire_seconds=None,
-                        **kwargs):
+                        expires=None, **kwargs):
+        if expire_seconds is None and isinstance(expires, (int, float)):
+            expire_seconds = int(expires)
         return {
             'queue': queue,
             'exchange': exchange,

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -612,8 +612,8 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         assert self.m1.crontab is None
 
     def test_expires_option_mapped_to_expire_seconds(self):
-        """Test that 'expires' in options is accepted as alias for
-        'expire_seconds', matching standard Celery apply_async API."""
+        """Test that numeric 'expires' values in options are accepted as
+        an alias for 'expire_seconds'."""
         name = f'expires_test{next(_ids)}'
         self.app.conf.beat_schedule[name] = {
             'task': f'djcelery.unittest.add{next(_ids)}',

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -611,6 +611,35 @@ class test_DatabaseSchedulerFromAppConf(SchedulerCase):
         assert self.m1.interval
         assert self.m1.crontab is None
 
+    def test_expires_option_mapped_to_expire_seconds(self):
+        """Test that 'expires' in options is accepted as alias for
+        'expire_seconds', matching standard Celery apply_async API."""
+        name = f'expires_test{next(_ids)}'
+        self.app.conf.beat_schedule[name] = {
+            'task': f'djcelery.unittest.add{next(_ids)}',
+            'schedule': timedelta(seconds=300),
+            'options': {'expires': 60},
+        }
+        s = self.Scheduler(app=self.app)
+        entry = s.schedule[name]
+        assert entry.model.expire_seconds == 60
+        assert entry.model.expires is None
+        assert entry.options['expires'] == 60
+
+    def test_expire_seconds_takes_precedence_over_expires(self):
+        """When both 'expire_seconds' and 'expires' are provided,
+        'expire_seconds' wins."""
+        name = f'expires_precedence{next(_ids)}'
+        self.app.conf.beat_schedule[name] = {
+            'task': f'djcelery.unittest.add{next(_ids)}',
+            'schedule': timedelta(seconds=300),
+            'options': {'expire_seconds': 120, 'expires': 60},
+        }
+        s = self.Scheduler(app=self.app)
+        entry = s.schedule[name]
+        assert entry.model.expire_seconds == 120
+        assert entry.options['expires'] == 120
+
 
 @pytest.mark.django_db
 class test_DatabaseScheduler(SchedulerCase):


### PR DESCRIPTION
While reconfiguring some beat tasks I have in the django settings, I stumbled upon the expiration of those.

According to the [Celery docs on tasks](https://docs.celeryq.dev/en/main/userguide/calling.html#expiration), I can pass `expires` to `apply_async` to avoid tasks being ran after some deadline.

According to the [Celery doc on periodic tasks](https://docs.celeryq.dev/en/main/userguide/periodic-tasks.html#available-fields), I can pass this kind of arguments in the `options` field. `expires` is even an example in the doc.

It works indeed when using the default `CELERY_BEAT_SCHEDULER`, but for django-celery-beat I had to use `expire_seconds` instead.

Here's a snippet of my current configuration to make it work across all schedulers:

```python
CELERY_BEAT_SCHEDULE = {
    "debug_heartbeat": {
        "task": "debug_task",
        "schedule": 10,
        "options": {
            "expires": 1, # works with the default scheduler
            "expire_seconds": 1, # works only with django-celery-beat scheduler
        },
    },
}
```

With this PR, `expires` works with django-celery-beat scheduler as well