### PR TITLE
Fix IntervalSchedule.from_schedule to use `period` parameter

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -197,7 +197,7 @@ class IntervalSchedule(models.Model):
     @classmethod
     def from_schedule(cls, schedule, period=SECONDS):
         period_delta = timedelta(**{period: 1})
-        every = int(max(schedule.run_every // period_delta, 0))
+        every = max(schedule.run_every // period_delta, 0)
         try:
             return cls.objects.get(every=every, period=period)
         except cls.DoesNotExist:

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -196,7 +196,8 @@ class IntervalSchedule(models.Model):
 
     @classmethod
     def from_schedule(cls, schedule, period=SECONDS):
-        every = max(schedule.run_every.total_seconds(), 0)
+        period_seconds = timedelta(**{period: 1}).total_seconds()
+        every = max(schedule.run_every.total_seconds() // period_seconds, 0)
         try:
             return cls.objects.get(every=every, period=period)
         except cls.DoesNotExist:

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -201,7 +201,9 @@ class IntervalSchedule(models.Model):
         try:
             return cls.objects.get(every=every, period=period)
         except cls.DoesNotExist:
-            return cls(every=every, period=period)
+            instance = cls(every=every, period=period)
+            instance.full_clean()
+            return instance
         except MultipleObjectsReturned:
             return cls.objects.filter(every=every, period=period).first()
 

--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -196,8 +196,8 @@ class IntervalSchedule(models.Model):
 
     @classmethod
     def from_schedule(cls, schedule, period=SECONDS):
-        period_seconds = timedelta(**{period: 1}).total_seconds()
-        every = max(schedule.run_every.total_seconds() // period_seconds, 0)
+        period_delta = timedelta(**{period: 1})
+        every = int(max(schedule.run_every // period_delta, 0))
         try:
             return cls.objects.get(every=every, period=period)
         except cls.DoesNotExist:

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -144,6 +144,42 @@ class IntervalScheduleTestCase(TestCase, TestDuplicatesMixin):
         schedule = schedules.schedule(run_every=1.0)
         self._test_duplicate_schedules(IntervalSchedule, kwargs, schedule)
 
+    def test_from_schedule_default_period_seconds(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(minutes=3))
+        result = IntervalSchedule.from_schedule(schedule)
+        self.assertEqual(result.every, 180)
+        self.assertEqual(result.period, IntervalSchedule.SECONDS)
+
+    def test_from_schedule_period_minutes(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(minutes=3))
+        result = IntervalSchedule.from_schedule(
+            schedule,
+            period=IntervalSchedule.MINUTES
+        )
+        self.assertEqual(result.every, 3)
+        self.assertEqual(result.period, IntervalSchedule.MINUTES)
+
+    def test_from_schedule_period_hours(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(hours=2))
+        result = IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.HOURS)
+        self.assertEqual(result.every, 2)
+        self.assertEqual(result.period, IntervalSchedule.HOURS)
+
+    def test_from_schedule_period_days(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(days=5))
+        result = IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.DAYS)
+        self.assertEqual(result.every, 5)
+        self.assertEqual(result.period, IntervalSchedule.DAYS)
+
+    def test_from_schedule_period_microseconds(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(microseconds=50_000))
+        result = IntervalSchedule.from_schedule(
+            schedule,
+            period=IntervalSchedule.MICROSECONDS
+        )
+        self.assertEqual(result.every, 50_000)
+        self.assertEqual(result.period, IntervalSchedule.MICROSECONDS)
+
 
 class ClockedScheduleTestCase(TestCase, TestDuplicatesMixin):
 

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -11,6 +11,7 @@ import pytest
 from celery import schedules
 from django.apps import apps
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
@@ -194,6 +195,11 @@ class IntervalScheduleTestCase(TestCase, TestDuplicatesMixin):
         self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 1)
         self.assertEqual(result.period, IntervalSchedule.MINUTES)
+
+    def test_from_schedule_period_raises_when_run_every_below_period(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(seconds=30))
+        with self.assertRaises(ValidationError):
+            IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.MINUTES)
 
 
 class ClockedScheduleTestCase(TestCase, TestDuplicatesMixin):

--- a/t/unit/test_models.py
+++ b/t/unit/test_models.py
@@ -147,6 +147,7 @@ class IntervalScheduleTestCase(TestCase, TestDuplicatesMixin):
     def test_from_schedule_default_period_seconds(self):
         schedule = schedules.schedule(run_every=datetime.timedelta(minutes=3))
         result = IntervalSchedule.from_schedule(schedule)
+        self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 180)
         self.assertEqual(result.period, IntervalSchedule.SECONDS)
 
@@ -156,18 +157,21 @@ class IntervalScheduleTestCase(TestCase, TestDuplicatesMixin):
             schedule,
             period=IntervalSchedule.MINUTES
         )
+        self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 3)
         self.assertEqual(result.period, IntervalSchedule.MINUTES)
 
     def test_from_schedule_period_hours(self):
         schedule = schedules.schedule(run_every=datetime.timedelta(hours=2))
         result = IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.HOURS)
+        self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 2)
         self.assertEqual(result.period, IntervalSchedule.HOURS)
 
     def test_from_schedule_period_days(self):
         schedule = schedules.schedule(run_every=datetime.timedelta(days=5))
         result = IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.DAYS)
+        self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 5)
         self.assertEqual(result.period, IntervalSchedule.DAYS)
 
@@ -177,8 +181,19 @@ class IntervalScheduleTestCase(TestCase, TestDuplicatesMixin):
             schedule,
             period=IntervalSchedule.MICROSECONDS
         )
+        self.assertIsInstance(result.every, int)
         self.assertEqual(result.every, 50_000)
         self.assertEqual(result.period, IntervalSchedule.MICROSECONDS)
+
+    def test_from_schedule_period_rounds_down(self):
+        schedule = schedules.schedule(run_every=datetime.timedelta(seconds=100))
+        result = IntervalSchedule.from_schedule(
+            schedule,
+            period=IntervalSchedule.MINUTES
+        )
+        self.assertIsInstance(result.every, int)
+        self.assertEqual(result.every, 1)
+        self.assertEqual(result.period, IntervalSchedule.MINUTES)
 
 
 class ClockedScheduleTestCase(TestCase, TestDuplicatesMixin):

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1433,7 +1433,7 @@ class test_models(SchedulerCase):
 
     def test_PeriodicTask_unicode_interval(self):
         p = self.create_model_interval(schedule(timedelta(seconds=10)))
-        assert str(p) == f'{p.name}: every 10.0 seconds'
+        assert str(p) == f'{p.name}: every 10 seconds'
 
     def test_PeriodicTask_unicode_crontab(self):
         p = self.create_model_crontab(crontab(


### PR DESCRIPTION
`IntervalSchedule.from_schedule()` is calculating `every` from seconds instead of the requested `period`, which gives the wrong value for periods like minutes, hours, days, and microseconds.

For example:

```python
from datetime import timedelta
from celery import schedules
from django_celery_beat.models import IntervalSchedule

schedule = schedules.schedule(run_every=timedelta(microseconds=50_000))
interval = IntervalSchedule.from_schedule(schedule, period=IntervalSchedule.MICROSECONDS)
print(interval)
# shows 0.05 microseconds, but should be 50000 microseconds
```
 Might be the root cause of #673.