### PR TITLE
Fix DatabaseScheduler re-dispatching tasks when sync() fails

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -446,18 +446,15 @@ class DatabaseScheduler(Scheduler):
     def sync(self):
         if logger.isEnabledFor(logging.DEBUG):
             debug('Writing entries...')
-        _tried = set()
-        _failed = set()
+        success = set()
         try:
             close_old_connections()
-
-            while self._dirty:
-                name = self._dirty.pop()
+            for name in self._dirty:
                 try:
                     self._schedule[name].save()
-                    _tried.add(name)
-                except (KeyError, TypeError, ObjectDoesNotExist):
-                    _failed.add(name)
+                    success.add(name)
+                except (KeyError, TypeError, ObjectDoesNotExist) as exc:
+                    debug('Skipping dirty entry %r in sync(): %r', name, exc)
         except DatabaseError as exc:
             logger.exception('Database error while sync: %r', exc)
         except InterfaceError:
@@ -466,8 +463,7 @@ class DatabaseScheduler(Scheduler):
                 'waiting to retry in next call...'
             )
         finally:
-            # retry later, only for the failed ones
-            self._dirty |= _failed
+            self._dirty -= success
 
     def update_from_dict(self, mapping):
         s = {}
@@ -501,6 +497,19 @@ class DatabaseScheduler(Scheduler):
             return False
         return super().schedules_equal(*args, **kwargs)
 
+    def _refresh_schedule(self):
+        fresh = self.all_as_schedule()
+        if not self._schedule:
+            return fresh
+        # Dirty entries aren't saved yet, keep their in-memory last_run_at / total_run_count
+        for name in self._dirty:
+            if name not in fresh or name not in self._schedule:
+                continue
+            old, new = self._schedule[name], fresh[name]
+            new.last_run_at = new.model.last_run_at = old.model.last_run_at
+            new.total_run_count = new.model.total_run_count = old.model.total_run_count
+        return fresh
+
     @property
     def schedule(self):
         initial = update = False
@@ -532,7 +541,7 @@ class DatabaseScheduler(Scheduler):
 
         if update:
             self.sync()
-            self._schedule = self.all_as_schedule()
+            self._schedule = self._refresh_schedule()
             # the schedule changed, invalidate the heap in Scheduler.tick
             if not initial:
                 self._heap = []

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -502,13 +502,14 @@ class DatabaseScheduler(Scheduler):
         if not self._schedule:
             return fresh
         # Dirty entries aren't saved yet,
-        # keep their in-memory last_run_at / total_run_count
+        # keep their in-memory run metadata
         for name in self._dirty:
             if name not in fresh or name not in self._schedule:
                 continue
             old, new = self._schedule[name], fresh[name]
             new.last_run_at = new.model.last_run_at = old.model.last_run_at
             new.total_run_count = new.model.total_run_count = old.model.total_run_count
+            new.model.no_changes = old.model.no_changes
         return fresh
 
     @property

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -501,7 +501,8 @@ class DatabaseScheduler(Scheduler):
         fresh = self.all_as_schedule()
         if not self._schedule:
             return fresh
-        # Dirty entries aren't saved yet, keep their in-memory last_run_at / total_run_count
+        # Dirty entries aren't saved yet,
+        # keep their in-memory last_run_at / total_run_count
         for name in self._dirty:
             if name not in fresh or name not in self._schedule:
                 continue

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -18,6 +18,8 @@ import pytest
 from celery.schedules import crontab, schedule, solar
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.utils import DatabaseError
 from django.test import RequestFactory, override_settings
 from django.utils import timezone
 
@@ -842,6 +844,54 @@ class test_DatabaseScheduler(SchedulerCase):
         assert self.s.flushed == 2
         assert e3.last_run_at == e2.last_run_at
         assert e3.args == [16, 16]
+
+    def test_database_error_during_sync_does_not_redispatch_task_on_next_tick(self):
+        # Disable m1 - its 10s interval would outrace m2 to the heap top
+        # on slow runs
+        self.m1.enabled = False
+        self.m1.save()
+
+        # Initial state: m2 starts overdue (interval is 20min,
+        # last run 30min ago)
+        m2 = PeriodicTask.objects.get(pk=self.m2.pk)
+        m2.last_run_at = timezone.now() - timedelta(minutes=30)
+        m2.save()
+
+        with patch.object(self.s, 'apply_entry') as apply_entry:
+            # First tick: m2 fires.
+            self.s.tick()
+            PeriodicTasks.update_changed()
+
+            with patch.object(schedulers.ModelEntry, 'save',
+                              side_effect=DatabaseError('boom')):
+                # Second tick: must not re-dispatch m2
+                self.s.tick()
+
+        m2_dispatches = [
+            call for call in apply_entry.call_args_list
+            if call.args and call.args[0].name == self.m2.name
+        ]
+        assert len(m2_dispatches) == 1
+
+    def test_sync_keeps_only_failed_entries_dirty_after_partial_success(self):
+        # reserve() advances each entry and adds it to _dirty.
+        self.s.reserve(self.s.schedule[self.m1.name])
+        self.s.reserve(self.s.schedule[self.m2.name])
+
+        saved = []
+
+        def fake_save(entry):
+            saved.append(entry.name)
+            if entry.name == self.m2.name:
+                raise ObjectDoesNotExist('gone')
+            # m1: succeed (no-op)
+
+        with patch.object(schedulers.ModelEntry, 'save', autospec=True,
+                          side_effect=fake_save):
+            self.s.sync()
+
+        assert set(saved) == {self.m1.name, self.m2.name}
+        assert self.s._dirty == {self.m2.name}
 
     def test_periodic_task_disabled_and_enabled(self):
         # Get the entry for m2

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -893,6 +893,19 @@ class test_DatabaseScheduler(SchedulerCase):
         assert set(saved) == {self.m1.name, self.m2.name}
         assert self.s._dirty == {self.m2.name}
 
+    def test_refresh_schedule_skips_dirty_entry_missing_from_db(self):
+        # reserve() advances m2 and marks it dirty.
+        self.s.reserve(self.s.schedule[self.m2.name])
+        assert self.m2.name in self.s._dirty
+
+        # The dirty entry is deleted before it gets synced, so it's
+        # absent from the freshly loaded schedule.
+        PeriodicTask.objects.filter(pk=self.m2.pk).delete()
+
+        fresh = self.s._refresh_schedule()
+        # The stale dirty entry is skipped, not carried over or raised on.
+        assert self.m2.name not in fresh
+
     def test_periodic_task_disabled_and_enabled(self):
         # Get the entry for m2
         e1 = self.s.schedule[self.m2.name]


### PR DESCRIPTION
## Description

When `sync()` fails to save entries that were dispatched, the next full reload via `all_as_schedule()` will overwrite the in-memory `last_run_at` and `total_run_count` with stale database values. As a result, beat may re-dispatch the same task on the next tick.

This change preserves in-memory run metadata for dirty entries across reloads.
Related to #558
