### PR TITLE
fix: cap is_due delay at start_time for one-off crontab tasks (#1044)

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -124,6 +124,15 @@ class ModelEntry(ScheduleEntry):
                 # send a delay to retry on start_time
                 current_tz = now.tzinfo
                 start_time = self.model.due_start_time(current_tz)
+                if self.model.one_off:
+                    # For a one-off PeriodicTask whose CrontabSchedule pins
+                    # day_of_month + month_of_year + day_of_week to fixed
+                    # values, CrontabSchedule.due_start_time() returns the
+                    # *next* matching calendar date, which is years in the
+                    # future. Without this cap, the task is delayed ~5
+                    # minutes (until the forced sync interval expires)
+                    # instead of firing at start_time. See issue #1044.
+                    start_time = min(start_time, self.model.start_time)
                 time_remaining = start_time - now
                 delay = math.ceil(time_remaining.total_seconds())
 

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1033,6 +1033,76 @@ class test_DatabaseScheduler(SchedulerCase):
         assert not is_due
         assert next_check == pytest.approx(expected_delay, abs=60)
 
+    def test_oneoff_crontab_fixed_date_does_not_delay_past_start_time(
+            self, app):
+        """Regression test for issue #1044.
+
+        A one-off PeriodicTask with a CrontabSchedule pinned to a specific
+        calendar date (day_of_month + month_of_year fixed) must wake up at
+        start_time, not at the next matching crontab date -- which can be
+        years in the future.
+
+        Before PR #844 (released in 2.8.0), is_due returned a delay of
+        ``(start_time - now)``. After #844, it returns
+        ``(crontab.due_start_time - now)``, which for fixed-date crontabs
+        computes the *next* matching date -- typically one year out for a
+        day_of_month + month_of_year pin -- causing tasks to fire ~5
+        minutes late (when the forced sync interval expires) instead of
+        at start_time.
+        """
+        now = app.now()
+
+        delay_minutes = 2
+        test_start_time = now + timedelta(minutes=delay_minutes)
+
+        task = self.create_model_crontab(
+            crontab(
+                minute=f'{test_start_time.minute}',
+                hour=f'{test_start_time.hour}',
+                day_of_month=f'{test_start_time.day}',
+                month_of_year=f'{test_start_time.month}',
+            ),
+            start_time=test_start_time,
+            one_off=True,
+        )
+
+        entry = EntryTrackSave(task, app=app)
+        is_due, next_check = entry.is_due()
+
+        expected_delay = delay_minutes * 60
+
+        assert not is_due
+        assert next_check == pytest.approx(expected_delay, abs=60)
+
+    def test_recurring_crontab_with_start_time_unaffected_by_oneoff_cap(
+            self, app):
+        """The fix for #1044 only caps one_off tasks; recurring crontabs
+        are unaffected by the cap and continue to use the post-#844
+        behavior (wake up at the next crontab match after start_time).
+        """
+        now = app.now()
+
+        delay_minutes = 2
+        test_start_time = now + timedelta(minutes=delay_minutes)
+        crontab_time = test_start_time + timedelta(minutes=delay_minutes)
+
+        task = self.create_model_crontab(
+            crontab(minute=f'{crontab_time.minute}'),
+            start_time=test_start_time,
+            one_off=False,
+        )
+
+        entry = EntryTrackSave(task, app=app)
+        is_due, next_check = entry.is_due()
+
+        # Same expectation as
+        # test_crontab_with_start_time_between_now_and_crontab
+        # (4 minutes = start_time delay + crontab delay).
+        expected_delay = 2 * delay_minutes * 60
+
+        assert not is_due
+        assert next_check == pytest.approx(expected_delay, abs=60)
+
     def test_crontab_with_start_time_different_time_zone(self, app):
         now = app.now()
 


### PR DESCRIPTION
For a one-off PeriodicTask whose CrontabSchedule pins day_of_month + month_of_year (and often day_of_week) to specific values, CrontabSchedule.due_start_time() returns the *next* matching calendar date -- typically one year in the future. ModelEntry.is_due() then returned this years-long delay, causing the task to fire ~5 minutes late (when the forced sync interval expires) instead of at start_time.

Cap the start_time used for delay computation by min()-ing with the user-specified model.start_time when model.one_off is True. Recurring crontabs are unaffected -- day_of_month='*' makes the next match at most 24h away, and the post-#844 wake-at-next-match behavior is desirable for them.

Fixes #1044