### PR TITLE
pre-commit: Add ruff rules for unsafe naive datetimes

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -159,7 +159,7 @@ class ModelEntry(ScheduleEntry):
         else:
             # this ends up getting passed to maybe_make_aware, which expects
             # all naive datetime objects to be in utc time.
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.utcnow()  # noqa: DTZ003 We want a naive datetime
         return now
 
     def __next__(self):
@@ -391,7 +391,7 @@ class DatabaseScheduler(Scheduler):
         target_tz = ZoneInfo(timezone_name)
 
         # Use a fixed point in time for the calculation to avoid DST issues
-        fixed_dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        fixed_dt = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=server_tz)
 
         # Calculate the offset
         dt1 = fixed_dt.replace(tzinfo=server_tz)
@@ -515,7 +515,7 @@ class DatabaseScheduler(Scheduler):
     @property
     def schedule(self):
         initial = update = False
-        current_time = datetime.datetime.now()
+        current_time = aware_now()
 
         if self._initial_read:
             debug('DatabaseScheduler: initial read')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ lint.select = [
   "C4",    # flake8-comprehensions
   "C90",   # McCabe cyclomatic complexity
   "DJ",    # flake8-django
+  "DTZ",   # flake8-datetimez
   "E",     # pycodestyle
   "EXE",   # flake8-executable
   "F",     # Pyflakes
   "FA",    # flake8-future-annotations
+  "FAST",  # FastAPI
   "FLY",   # flynt
   "FURB",  # refurb
   "G",     # flake8-logging-format
@@ -32,6 +34,8 @@ lint.select = [
   "SIM",   # flake8-simplify
   "SLOT",  # flake8-slots
   "T10",   # flake8-debugger
+  "T10",   # flake8-debugger
+  "T20",   # flake8-print
   "TCH",   # flake8-type-checking
   "TID",   # flake8-tidy-imports
   "UP",    # pyupgrade
@@ -43,7 +47,6 @@ lint.select = [
   # "COM",  # flake8-commas
   # "CPY",  # flake8-copyright
   # "D",    # pydocstyle
-  # "DTZ",  # flake8-datetimez
   # "EM",   # flake8-errmsg
   # "ERA",  # eradicate
   # "FBT",  # flake8-boolean-trap
@@ -56,7 +59,6 @@ lint.select = [
   # "RET",  # flake8-return
   # "RUF",  # Ruff-specific rules
   # "SLF",  # flake8-self
-  # "T20",  # flake8-print
   # "TD",   # flake8-todos
   # "TRY",  # tryceratops
 ]

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -1,3 +1,5 @@
+# ruff: noqa: DTZ001,DTZ003,DTZ005  # many tests require naive datetimes
+
 import math
 import os
 import time


### PR DESCRIPTION
Fixes: #1059

Lint rules to ban the usage of unsafe [`naive datetimes`](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects).
* https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz

% `ruff check --select=DTZ --statistics`
```
7	DTZ001	call-datetime-without-tzinfo
7	DTZ005	call-datetime-now-without-tzinfo
5	DTZ003	call-datetime-utcnow
Found 19 errors.
```
Related to:
* #1059 