### PR TITLE
ci: Drop the archived GitHub Action useblacksmith/setup-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: useblacksmith/setup-python@v6
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: useblacksmith/setup-python@v6
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true


### PR DESCRIPTION
As recommended in the ***archive notice*** for the GitHub Action `useblacksmith/setup-python`:
* https://github.com/useblacksmith/setup-python#%EF%B8%8F-archive-notice
> Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect, it is recommended to switch to the upstream, maintained versions of this action, as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.

This change removes all the Node.js warnings at the bottom right of:
* https://github.com/celery/django-celery-beat/actions/runs/28693513640