### PR TITLE
Fix tasks not firing after edit when USE_TZ=False

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -19,6 +19,7 @@ from django.db import close_old_connections, transaction
 from django.db.models import Case, F, IntegerField, Q, When
 from django.db.models.functions import Cast
 from django.db.utils import DatabaseError, InterfaceError
+from django.utils import timezone
 from kombu.utils.encoding import safe_repr, safe_str
 from kombu.utils.json import dumps, loads
 
@@ -94,6 +95,23 @@ class ModelEntry(ScheduleEntry):
 
         if not model.last_run_at:
             model.last_run_at = model.date_changed or self._default_now()
+            # When USE_TZ is False, Django's auto_now writes date_changed as a
+            # naive datetime in settings.TIME_ZONE (local time). is_due() feeds
+            # last_run_at to maybe_make_aware, which assumes naive == UTC, so
+            # date_changed must be normalized to naive UTC to avoid a timezone-
+            # offset shift. aware values (USE_TZ=True) are left as-is.
+            # The normalized value is persisted on save() and thus coexists
+            # with date_changed (naive local time) in the DB under different
+            # timezone semantics; this is unavoidable for naive datetimes.
+            if (
+                model.date_changed
+                and not getattr(settings, 'USE_TZ', False)
+                and timezone.is_naive(model.last_run_at)
+            ):
+                model.last_run_at = timezone.make_aware(
+                    model.last_run_at,
+                    timezone.get_default_timezone(),
+                ).astimezone(datetime.timezone.utc).replace(tzinfo=None)
             # if last_run_at is not set and
             # model.start_time last_run_at should be in way past.
             # This will trigger the job to run at start_time

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -470,6 +470,62 @@ class test_ModelEntry(SchedulerCase):
         if hasattr(time, "tzset"):
             time.tzset()
 
+    @override_settings(
+        USE_TZ=False,
+        DJANGO_CELERY_BEAT_TZ_AWARE=False,
+        TIME_ZONE='Europe/Berlin',
+    )
+    @pytest.mark.usefixtures('depends_on_current_app')
+    @timezone.override('Europe/Berlin')
+    @pytest.mark.celery(timezone='Europe/Berlin')
+    def test_entry_is_due_after_edit_uses_date_changed_no_use_tz(self):
+        # Editing a task clears last_run_at (see PeriodicTask.save), so on
+        # reload the entry falls back to model.date_changed. Under USE_TZ=False
+        # and a non-UTC TIME_ZONE, date_changed is a naive *local* datetime
+        # (Django auto_now), while _default_now() returns naive UTC. is_due()'s
+        # maybe_make_aware assumes naive == UTC, so date_changed must be
+        # normalized to naive UTC first; otherwise last_run_at lands hours in
+        # the future and the task stops firing after a manual edit.
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Europe/Berlin"
+        if hasattr(time, "tzset"):
+            time.tzset()
+        try:
+            assert self.app.timezone.key == 'Europe/Berlin'
+
+            m = self.create_model_crontab(crontab(minute='*/10'))
+            m.save()
+            m.refresh_from_db()
+            assert m.date_changed is not None
+
+            # Simulate the post-edit reload: last_run_at cleared, so the entry
+            # reconstructs it from date_changed (a naive Berlin datetime here).
+            m.last_run_at = None
+            e = self.Entry(m, app=self.app)
+
+            # date_changed is Berlin local; normalized last_run_at must be the
+            # UTC equivalent (1 or 2 hours earlier, depending on DST), not the
+            # local value. Assert the exact UTC equivalent so the check holds
+            # regardless of the season in which the test runs.
+            expected_utc = (
+                timezone.make_aware(m.date_changed, timezone.get_default_timezone())
+                .astimezone(dt_timezone.utc)
+                .replace(tzinfo=None)
+            )
+            assert e.last_run_at == expected_utc
+
+            # last_run_at must not be in the future: is_due reports the task is
+            # due now or within the next 10-minute slot, not hours away.
+            due = e.is_due()
+            assert due.next <= 600  # 10 minutes
+        finally:
+            if old_tz is not None:
+                os.environ["TZ"] = old_tz
+            else:
+                del os.environ["TZ"]
+            if hasattr(time, "tzset"):
+                time.tzset()
+
     def test_task_with_start_time(self):
         interval = 10
         right_now = self.app.now()


### PR DESCRIPTION
## Summary

Fixes a bug where a periodic task stops firing after being manually edited, when the project runs with `USE_TZ=False` and the default `DJANGO_CELERY_BEAT_TZ_AWARE=False`.

## Problem

Editing a `PeriodicTask` clears `last_run_at` (`PeriodicTask.save` sets it to `None` when the task is re-enabled). On the scheduler's next reload, the entry reconstructs `last_run_at` from `model.date_changed`:

```python
# schedulers.py
if not model.last_run_at:
    model.last_run_at = model.date_changed or self._default_now()
```

Under `USE_TZ=False`, the two candidate sources write naive datetimes with **different timezone semantics**:

| source | naive datetime meaning |
| --- | --- |
| `date_changed` (Django `auto_now`) | `settings.TIME_ZONE` local time |
| `_default_now()` (`TZ_AWARE=False` -> `utcnow()`) | UTC |

`is_due()` then does:

```python
last_run_at_in_tz = maybe_make_aware(self.last_run_at).astimezone(tz)
```

`maybe_make_aware` assumes naive == UTC. So a `date_changed` written as local time gets reinterpreted as UTC and shifted by the local UTC offset. For `TIME_ZONE=Asia/Shanghai` (UTC+8), `last_run_at` lands 8 hours **into the future**. `crontab.remaining_estimate` then sees a future `last_run_at`, returns a large `next`, and the task is parked in the heap hours away - it stops firing until that time elapses.

Normal operation is unaffected because `last_run_at` then comes from `_default_now()` (naive UTC), which matches `maybe_make_aware`'s assumption. The bug only surfaces when the `date_changed` fallback path runs, i.e. after a task is created or edited.

This is a gap left by #294, which made `_default_now()` return naive UTC to match `maybe_make_aware`, but did not address `date_changed` - a Django-managed field it cannot control. The existing caution comment in `is_due()` already documents that the two helpers disagree on naive datetimes:

```python
# CAUTION: make_aware assumes settings.TIME_ZONE for naive datetimes,
# while maybe_make_aware assumes utc for naive datetimes
```

## Reproduction

Config:

```python
TIME_ZONE = "Asia/Shanghai"
USE_TZ = False
DJANGO_CELERY_BEAT_TZ_AWARE = False
```

1. Create a crontab task (`*/10` minutes).
2. Wait for it to fire once (works fine - `last_run_at` from `_default_now()`).
3. Manually edit and save the task in admin.
4. The task no longer fires; `is_due()` returns a `next` value on the order of hours (the UTC offset) instead of ≤ 10 minutes.

## Fix

Normalize `date_changed` to naive UTC before it is used as `last_run_at`, so it agrees with `_default_now()`:

```python
if (
    model.date_changed
    and not getattr(settings, 'USE_TZ', False)
    and timezone.is_naive(model.last_run_at)
):
    model.last_run_at = timezone.make_aware(
        model.last_run_at,
        timezone.get_default_timezone(),
    ).astimezone(datetime.timezone.utc).replace(tzinfo=None)
```

- `USE_TZ=True`: `date_changed` is already aware -> condition is false -> no change (regression-safe).
- `USE_TZ=False`: `date_changed` is naive local -> converted to naive UTC, matching `_default_now()`.

## Tests

Added `test_entry_is_due_after_edit_uses_date_changed_no_use_tz`, which sets `USE_TZ=False` + `TIME_ZONE='Europe/Berlin'` (the non-UTC `TIME_ZONE` is what triggers the bug - existing `no_use_tz` tests use the default `TIME_ZONE='UTC'`, which is why they never caught it), simulates the post-edit reload (`last_run_at=None`), and asserts:

- `last_run_at` is normalized to the UTC equivalent (2h earlier in summer), not left as the local value.
- `is_due().next <= 600` (within one schedule slot), not hours away.

Verified the test fails without the fix and passes with it. Full `test_schedulers.py` passes (the 2 `PeriodicTaskAdmin::test_run_task*` failures are pre-existing and unrelated - they require a live broker).