### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,96 @@
+# Mirrored from .gitignore
+.DS_Store
+*.pyc
+*$py.class
+*~
+.*.sw[pon]
+dist/
+*.egg-info
+*.egg
+*.egg/
+build/
+.build/
+_build/
+pip-log.txt
+.directory
+erl_crash.dump
+*.db
+Documentation/
+.tox/
+.ropeproject/
+.project
+.pydevproject
+.idea/
+.vscode/
+.coverage
+celery/tests/cover/
+.ve*
+cover/
+.vagrant/
+*.sqlite3
+.cache/
+htmlcov/
+coverage.xml
+.eggs/
+.python-version
+venv
+.env
+
+# Docker-specific
+# Git history and metadata
+.git/
+.gitignore
+
+# Environment files — never bake secrets into the image
+.env
+.env.*
+!.env.example
+
+# Documentation
+*.md
+docs/
+LICENSE
+CHANGELOG*
+
+# CI/CD configuration
+.github/
+.gitlab/
+
+# Docker tooling
+docker-compose.yml
+docker-compose*.yml
+.dockerignore
+
+# Development tooling
+Makefile
+.editorconfig
+
+# Test suites and coverage
+tests/
+test/
+spec/
+__tests__/
+coverage/
+.pytest_cache/
+.nyc_output/
+
+# Language runtime caches
+node_modules/
+__pycache__/
+*.pyc
+.venv/
+venv/
+vendor/
+
+# Build artefacts
+dist/
+build/
+target/
+out/
+
+# IDE and OS files
+.idea/
+.vscode/
+.DS_Store
+*.swp
+*.log


### PR DESCRIPTION
The repository has a `Dockerfile` but no `.dockerignore`. Without one, Docker
sends the full build context to the daemon — including `.git/`, test suites,
documentation, CI configuration, and development tooling — on every build.
This slows builds and risks accidentally baking sensitive files into images.

The added `.dockerignore` excludes:

- `.git/` and VCS metadata
- Environment files (`.env`, `.env.*`, with a `!.env.example` carve-out)
- Test suites and coverage outputs
- Documentation (`*.md`, `docs/`, `LICENSE`, `CHANGELOG*`)
- CI configuration (`.github/`, `.gitlab/`)
- Development tooling (`Makefile`, `.editorconfig`, `.idea/`, `.vscode/`)
- Build artefacts (`dist/`, `build/`)
- Language runtime caches (`__pycache__/`, `.venv/`, `*.pyc`)

Entries mirror the existing `.gitignore` where relevant, so the two files
stay consistent.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.