### PR TITLE
Limit is_due() one-off save to the fields it modifies

### DIFF
--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -161,7 +161,11 @@ class ModelEntry(ScheduleEntry):
             self.model.enabled = False
             self.model.total_run_count = 0  # Reset
             self.model.no_changes = False  # Mark the model entry as changed
-            self.model.save()
+            # Persist only the fields this branch modifies; a full save() of this
+            # cached instance would clobber concurrent DB changes (see #1069).
+            self.model.save(update_fields=[
+                'enabled', 'total_run_count', 'date_changed',
+            ])
             # Don't recheck
             return schedules.schedstate(False, NEVER_CHECK_TIMEOUT)
 

--- a/django_celery_beat/schedulers.py
+++ b/django_celery_beat/schedulers.py
@@ -161,10 +161,10 @@ class ModelEntry(ScheduleEntry):
             self.model.enabled = False
             self.model.total_run_count = 0  # Reset
             self.model.no_changes = False  # Mark the model entry as changed
-            # Persist only the fields this branch modifies; a full save() of this
-            # cached instance would clobber concurrent DB changes (see #1069).
+            # Persist only the fields this branch modifies; include last_run_at
+            # because PeriodicTask.save() clears it when enabled=False (see #1069).
             self.model.save(update_fields=[
-                'enabled', 'total_run_count', 'date_changed',
+                'enabled', 'total_run_count', 'last_run_at', 'date_changed',
             ])
             # Don't recheck
             return schedules.schedstate(False, NEVER_CHECK_TIMEOUT)

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -574,10 +574,39 @@ class test_ModelEntry(SchedulerCase):
             last_run_at=one_interval_ago,
             total_run_count=1
         )
+        m2.save()   # persist: is_due()'s one-off branch updates the row via update_fields
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue
         assert delay == NEVER_CHECK_TIMEOUT
+
+    def test_one_off_disable_uses_update_fields(self):
+        """is_due() for a fired one-off must not full-save the cached instance.
+
+        A full-field save silently overwrites concurrent database changes to
+        the row (and can raise IntegrityError if a related record was
+        deleted concurrently).
+        """
+        task = self.create_model_crontab(
+            crontab(minute='*'),
+            one_off=True,
+            total_run_count=1,
+        )
+        task.save()
+        entry = self.Entry(task, app=self.app)
+
+        # Simulate a concurrent change made after the entry cached the model
+        PeriodicTask.objects.filter(pk=task.pk).update(
+            description='changed concurrently')
+
+        entry.is_due()
+
+        task.refresh_from_db()
+        assert task.enabled is False
+        assert task.total_run_count == 0
+        # The concurrent change must survive; a full-field save would have
+        # clobbered it with the stale cached value.
+        assert task.description == 'changed concurrently'
 
     def test_task_with_expires(self):
         interval = 10

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -604,6 +604,7 @@ class test_ModelEntry(SchedulerCase):
         task.refresh_from_db()
         assert task.enabled is False
         assert task.total_run_count == 0
+        assert task.last_run_at is None
         # The concurrent change must survive; a full-field save would have
         # clobbered it with the stale cached value.
         assert task.description == 'changed concurrently'

--- a/t/unit/test_schedulers.py
+++ b/t/unit/test_schedulers.py
@@ -574,7 +574,7 @@ class test_ModelEntry(SchedulerCase):
             last_run_at=one_interval_ago,
             total_run_count=1
         )
-        m2.save()   # persist: is_due()'s one-off branch updates the row via update_fields
+        m2.save()  # persist: is_due() one-off branch updates the row via update_fields
         e2 = self.Entry(m2, app=self.app)
         isdue, delay = e2.is_due()
         assert not isdue


### PR DESCRIPTION
Closes #1069 

# What's Changed

ModelEntry.is_due() performed an unconditional full-field save() of the long-lived cached PeriodicTask instance when disabling a fired one-off task. This silently overwrote any concurrent database changes to the row (lost update), and when the overwritten change was a `SET_NULL` from a cascading delete of a related record, the write violated the FK constraint and the resulting IntegrityError crashed the entire beat process, since Scheduler.tick() has no error isolation around is_due().

Persist only the fields this branch modifies (enabled, total_run_count, date_changed)