### PR TITLE
Update celery and importlib-metadata requirements

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
-celery>=5.2.3,<6.0
-importlib-metadata<5.0; python_version<"3.8" # TODO: remove this when celery >= 5.3.0
+celery>=5.3.0,<6.0
+importlib-metadata
 django-timezone-field>=7.2.1
 backports.zoneinfo; python_version<"3.9"
 tzdata

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,4 @@
 celery>=5.3.0,<6.0
-importlib-metadata
 django-timezone-field>=7.2.1
 backports.zoneinfo; python_version<"3.9"
 tzdata


### PR DESCRIPTION
Updated celery version requirement and removed importlib-metadata version constraint.

Resolves #1081 